### PR TITLE
Fixed and empty log error when using Output.SentToTerminal

### DIFF
--- a/core/AutoCheck.Core.csproj
+++ b/core/AutoCheck.Core.csproj
@@ -6,7 +6,7 @@
     <Authors>Fernando Porrino Serrano</Authors>
     <Product>AutoCheck.Core</Product>
     <Copyright>Copyright © 2021</Copyright>
-    <VersionPrefix>2.11.0</VersionPrefix>
+    <VersionPrefix>2.11.1</VersionPrefix>
     <VersionSuffix>stable</VersionSuffix>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion> 
     <AssemblyFileVersion>$(AssemblyVersion)</AssemblyFileVersion>

--- a/core/main/Output.cs
+++ b/core/main/Output.cs
@@ -281,6 +281,7 @@ namespace AutoCheck.Core{
         /// </summary>   
         /// <param name="log">The log to print.</param>     
         public void SendToTerminal(Log log){
+            if(log == null || log.Content == null) return;
             foreach(Content c in log.Content){
                 SendToTerminal(c);         
             }

--- a/test/main/Script.cs/Output.cs
+++ b/test/main/Script.cs/Output.cs
@@ -28,7 +28,27 @@ namespace AutoCheck.Test
     public class Output : Test
     {
         public Output(): base("script"){
-        }        
+        }   
+
+        [Test, Category("Output"), Category("Local"), Category("Text")]
+        public void Output_SendToTerminal_NotNull()
+        {             
+            var logFilePath = Path.Combine(LogRootFolder, "script", "output", "output_single_1_yaml", "OUTPUT SINGLE 1_Student Name 1.log");
+            if(File.Exists(logFilePath)) File.Delete(logFilePath);
+            
+            var s = new AutoCheck.Core.Script(GetSampleFile("output_single_1.yaml"));
+            s.Output.SendToTerminal(s.Output.GetLog().FirstOrDefault());            
+        } 
+
+        [Test, Category("Output"), Category("Local"), Category("Text")]
+        public void Output_SendToTerminal_Null()
+        {             
+            var logFilePath = Path.Combine(LogRootFolder, "script", "output", "output_single_1_yaml", "OUTPUT SINGLE 1_Student Name 1.log");
+            if(File.Exists(logFilePath)) File.Delete(logFilePath);
+            
+            var s = new AutoCheck.Core.Script(GetSampleFile("output_single_1.yaml"));
+            s.Output.SendToTerminal(null);            
+        }     
        
         [Test, Category("Output"), Category("Local"), Category("Text")]
         public void Output_SINGLE_FILE_1()


### PR DESCRIPTION
Fixed a bug when trying to send empty log data to the terminal through Output.SendToTerminal().