### PR TITLE
V2.12.2

### DIFF
--- a/core/AutoCheck.Core.csproj
+++ b/core/AutoCheck.Core.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildDocFx>false</BuildDocFx>  <!-- Set this value to 'true' in order to build the documentation. -->
+    <BuildDocFx>true</BuildDocFx>  <!-- Set this value to 'true' in order to build the documentation. -->
     <InvariantGlobalization>true</InvariantGlobalization>
     <TargetFramework>net6.0</TargetFramework>
     <Authors>Fernando Porrino Serrano</Authors>
     <Product>AutoCheck.Core</Product>
     <Copyright>Copyright © 2021</Copyright>
-    <VersionPrefix>2.12.1</VersionPrefix>
+    <VersionPrefix>2.12.2</VersionPrefix>
     <VersionSuffix>stable</VersionSuffix>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion> 
     <AssemblyFileVersion>$(AssemblyVersion)</AssemblyFileVersion>

--- a/core/AutoCheck.Core.csproj
+++ b/core/AutoCheck.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <BuildDocFx>true</BuildDocFx>  <!-- Set this value to 'true' in order to build the documentation. -->
+    <BuildDocFx>false</BuildDocFx>  <!-- Set this value to 'true' in order to build the documentation. -->
     <InvariantGlobalization>true</InvariantGlobalization>
     <TargetFramework>net6.0</TargetFramework>
     <Authors>Fernando Porrino Serrano</Authors>

--- a/docs/api/AutoCheck.Core.Connectors.Atom.yml
+++ b/docs/api/AutoCheck.Core.Connectors.Atom.yml
@@ -20,7 +20,7 @@ items:
   source:
     remote:
       path: core/connectors/Atom.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Atom
     path: ../core/connectors/Atom.cs
@@ -74,7 +74,7 @@ items:
   source:
     remote:
       path: core/connectors/Atom.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/connectors/Atom.cs
@@ -110,7 +110,7 @@ items:
   source:
     remote:
       path: core/connectors/Atom.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/connectors/Atom.cs
@@ -153,7 +153,7 @@ items:
   source:
     remote:
       path: core/connectors/Atom.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/connectors/Atom.cs
@@ -194,7 +194,7 @@ items:
   source:
     remote:
       path: core/connectors/Atom.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Dispose
     path: ../core/connectors/Atom.cs
@@ -229,7 +229,7 @@ items:
   source:
     remote:
       path: core/connectors/Atom.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ValidateAtomAgainstW3C
     path: ../core/connectors/Atom.cs

--- a/docs/api/AutoCheck.Core.Connectors.Base.yml
+++ b/docs/api/AutoCheck.Core.Connectors.Base.yml
@@ -17,7 +17,7 @@ items:
   source:
     remote:
       path: core/connectors/Base.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Base
     path: ../core/connectors/Base.cs
@@ -69,7 +69,7 @@ items:
   source:
     remote:
       path: core/connectors/Base.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Dispose
     path: ../core/connectors/Base.cs
@@ -103,7 +103,7 @@ items:
   source:
     remote:
       path: core/connectors/Base.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ProcessRemoteFile
     path: ../core/connectors/Base.cs

--- a/docs/api/AutoCheck.Core.Connectors.Css.yml
+++ b/docs/api/AutoCheck.Core.Connectors.Css.yml
@@ -31,7 +31,7 @@ items:
   source:
     remote:
       path: core/connectors/Css.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Css
     path: ../core/connectors/Css.cs
@@ -73,7 +73,7 @@ items:
   source:
     remote:
       path: core/connectors/Css.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CssDoc
     path: ../core/connectors/Css.cs
@@ -111,7 +111,7 @@ items:
   source:
     remote:
       path: core/connectors/Css.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Raw
     path: ../core/connectors/Css.cs
@@ -149,7 +149,7 @@ items:
   source:
     remote:
       path: core/connectors/Css.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/connectors/Css.cs
@@ -185,7 +185,7 @@ items:
   source:
     remote:
       path: core/connectors/Css.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/connectors/Css.cs
@@ -228,7 +228,7 @@ items:
   source:
     remote:
       path: core/connectors/Css.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/connectors/Css.cs
@@ -269,7 +269,7 @@ items:
   source:
     remote:
       path: core/connectors/Css.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Dispose
     path: ../core/connectors/Css.cs
@@ -304,7 +304,7 @@ items:
   source:
     remote:
       path: core/connectors/Css.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ValidateCss3AgainstW3C
     path: ../core/connectors/Css.cs
@@ -336,7 +336,7 @@ items:
   source:
     remote:
       path: core/connectors/Css.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: PropertyExists
     path: ../core/connectors/Css.cs
@@ -378,7 +378,7 @@ items:
   source:
     remote:
       path: core/connectors/Css.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: PropertyExists
     path: ../core/connectors/Css.cs
@@ -420,7 +420,7 @@ items:
   source:
     remote:
       path: core/connectors/Css.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: PropertyExists
     path: ../core/connectors/Css.cs
@@ -462,7 +462,7 @@ items:
   source:
     remote:
       path: core/connectors/Css.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: PropertyApplied
     path: ../core/connectors/Css.cs
@@ -501,7 +501,7 @@ items:
   source:
     remote:
       path: core/connectors/Css.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: PropertyApplied
     path: ../core/connectors/Css.cs
@@ -546,7 +546,7 @@ items:
   source:
     remote:
       path: core/connectors/Css.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: PropertyApplied
     path: ../core/connectors/Css.cs
@@ -591,7 +591,7 @@ items:
   source:
     remote:
       path: core/connectors/Css.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: PropertyApplied
     path: ../core/connectors/Css.cs
@@ -630,7 +630,7 @@ items:
   source:
     remote:
       path: core/connectors/Css.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: PropertyApplied
     path: ../core/connectors/Css.cs
@@ -675,7 +675,7 @@ items:
   source:
     remote:
       path: core/connectors/Css.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: PropertyApplied
     path: ../core/connectors/Css.cs

--- a/docs/api/AutoCheck.Core.Connectors.Csv.yml
+++ b/docs/api/AutoCheck.Core.Connectors.Csv.yml
@@ -20,7 +20,7 @@ items:
   source:
     remote:
       path: core/connectors/Csv.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Csv
     path: ../core/connectors/Csv.cs
@@ -62,7 +62,7 @@ items:
   source:
     remote:
       path: core/connectors/Csv.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CsvDoc
     path: ../core/connectors/Csv.cs
@@ -100,7 +100,7 @@ items:
   source:
     remote:
       path: core/connectors/Csv.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/connectors/Csv.cs
@@ -142,7 +142,7 @@ items:
   source:
     remote:
       path: core/connectors/Csv.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/connectors/Csv.cs
@@ -189,7 +189,7 @@ items:
   source:
     remote:
       path: core/connectors/Csv.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/connectors/Csv.cs
@@ -234,7 +234,7 @@ items:
   source:
     remote:
       path: core/connectors/Csv.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Dispose
     path: ../core/connectors/Csv.cs

--- a/docs/api/AutoCheck.Core.Connectors.CsvDocument.yml
+++ b/docs/api/AutoCheck.Core.Connectors.CsvDocument.yml
@@ -21,7 +21,7 @@ items:
   source:
     remote:
       path: core/connectors/Csv.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CsvDocument
     path: ../core/connectors/Csv.cs
@@ -60,7 +60,7 @@ items:
   source:
     remote:
       path: core/connectors/Csv.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Content
     path: ../core/connectors/Csv.cs
@@ -98,7 +98,7 @@ items:
   source:
     remote:
       path: core/connectors/Csv.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Headers
     path: ../core/connectors/Csv.cs
@@ -136,7 +136,7 @@ items:
   source:
     remote:
       path: core/connectors/Csv.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Count
     path: ../core/connectors/Csv.cs
@@ -174,7 +174,7 @@ items:
   source:
     remote:
       path: core/connectors/Csv.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/connectors/Csv.cs
@@ -216,7 +216,7 @@ items:
   source:
     remote:
       path: core/connectors/Csv.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Validate
     path: ../core/connectors/Csv.cs
@@ -248,7 +248,7 @@ items:
   source:
     remote:
       path: core/connectors/Csv.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetLine
     path: ../core/connectors/Csv.cs

--- a/docs/api/AutoCheck.Core.Connectors.GDrive.yml
+++ b/docs/api/AutoCheck.Core.Connectors.GDrive.yml
@@ -48,7 +48,7 @@ items:
   source:
     remote:
       path: core/connectors/GDrive.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GDrive
     path: ../core/connectors/GDrive.cs
@@ -90,7 +90,7 @@ items:
   source:
     remote:
       path: core/connectors/GDrive.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Drive
     path: ../core/connectors/GDrive.cs
@@ -125,7 +125,7 @@ items:
   source:
     remote:
       path: core/connectors/GDrive.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/connectors/GDrive.cs
@@ -164,7 +164,7 @@ items:
   source:
     remote:
       path: core/connectors/GDrive.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/connectors/GDrive.cs
@@ -207,7 +207,7 @@ items:
   source:
     remote:
       path: core/connectors/GDrive.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/connectors/GDrive.cs
@@ -252,7 +252,7 @@ items:
   source:
     remote:
       path: core/connectors/GDrive.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Dispose
     path: ../core/connectors/GDrive.cs
@@ -287,7 +287,7 @@ items:
   source:
     remote:
       path: core/connectors/GDrive.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CreateFolder
     path: ../core/connectors/GDrive.cs
@@ -325,7 +325,7 @@ items:
   source:
     remote:
       path: core/connectors/GDrive.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CreateFolder
     path: ../core/connectors/GDrive.cs
@@ -366,7 +366,7 @@ items:
   source:
     remote:
       path: core/connectors/GDrive.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetFolder
     path: ../core/connectors/GDrive.cs
@@ -404,7 +404,7 @@ items:
   source:
     remote:
       path: core/connectors/GDrive.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetFolder
     path: ../core/connectors/GDrive.cs
@@ -449,7 +449,7 @@ items:
   source:
     remote:
       path: core/connectors/GDrive.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CountFolders
     path: ../core/connectors/GDrive.cs
@@ -491,7 +491,7 @@ items:
   source:
     remote:
       path: core/connectors/GDrive.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: DeleteFolder
     path: ../core/connectors/GDrive.cs
@@ -527,7 +527,7 @@ items:
   source:
     remote:
       path: core/connectors/GDrive.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: DeleteFolder
     path: ../core/connectors/GDrive.cs
@@ -566,7 +566,7 @@ items:
   source:
     remote:
       path: core/connectors/GDrive.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ExistsFolder
     path: ../core/connectors/GDrive.cs
@@ -604,7 +604,7 @@ items:
   source:
     remote:
       path: core/connectors/GDrive.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ExistsFolder
     path: ../core/connectors/GDrive.cs
@@ -649,7 +649,7 @@ items:
   source:
     remote:
       path: core/connectors/GDrive.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: UploadFolder
     path: ../core/connectors/GDrive.cs
@@ -691,7 +691,7 @@ items:
   source:
     remote:
       path: core/connectors/GDrive.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: UploadFolder
     path: ../core/connectors/GDrive.cs
@@ -736,7 +736,7 @@ items:
   source:
     remote:
       path: core/connectors/GDrive.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetFile
     path: ../core/connectors/GDrive.cs
@@ -774,7 +774,7 @@ items:
   source:
     remote:
       path: core/connectors/GDrive.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetFile
     path: ../core/connectors/GDrive.cs
@@ -819,7 +819,7 @@ items:
   source:
     remote:
       path: core/connectors/GDrive.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CountFiles
     path: ../core/connectors/GDrive.cs
@@ -861,7 +861,7 @@ items:
   source:
     remote:
       path: core/connectors/GDrive.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CreateFile
     path: ../core/connectors/GDrive.cs
@@ -903,7 +903,7 @@ items:
   source:
     remote:
       path: core/connectors/GDrive.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: DeleteFile
     path: ../core/connectors/GDrive.cs
@@ -939,7 +939,7 @@ items:
   source:
     remote:
       path: core/connectors/GDrive.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: DeleteFile
     path: ../core/connectors/GDrive.cs
@@ -978,7 +978,7 @@ items:
   source:
     remote:
       path: core/connectors/GDrive.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CopyFile
     path: ../core/connectors/GDrive.cs
@@ -1020,7 +1020,7 @@ items:
   source:
     remote:
       path: core/connectors/GDrive.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CopyFile
     path: ../core/connectors/GDrive.cs
@@ -1062,7 +1062,7 @@ items:
   source:
     remote:
       path: core/connectors/GDrive.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CopyFile
     path: ../core/connectors/GDrive.cs
@@ -1104,7 +1104,7 @@ items:
   source:
     remote:
       path: core/connectors/GDrive.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CopyFromFile
     path: ../core/connectors/GDrive.cs
@@ -1146,7 +1146,7 @@ items:
   source:
     remote:
       path: core/connectors/GDrive.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: UploadFile
     path: ../core/connectors/GDrive.cs
@@ -1189,7 +1189,7 @@ items:
   source:
     remote:
       path: core/connectors/GDrive.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Download
     path: ../core/connectors/GDrive.cs
@@ -1226,7 +1226,7 @@ items:
   source:
     remote:
       path: core/connectors/GDrive.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Download
     path: ../core/connectors/GDrive.cs
@@ -1263,7 +1263,7 @@ items:
   source:
     remote:
       path: core/connectors/GDrive.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Download
     path: ../core/connectors/GDrive.cs
@@ -1300,7 +1300,7 @@ items:
   source:
     remote:
       path: core/connectors/GDrive.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: DownloadFromFile
     path: ../core/connectors/GDrive.cs
@@ -1337,7 +1337,7 @@ items:
   source:
     remote:
       path: core/connectors/GDrive.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ExistsFile
     path: ../core/connectors/GDrive.cs
@@ -1375,7 +1375,7 @@ items:
   source:
     remote:
       path: core/connectors/GDrive.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ExistsFile
     path: ../core/connectors/GDrive.cs

--- a/docs/api/AutoCheck.Core.Connectors.Html.yml
+++ b/docs/api/AutoCheck.Core.Connectors.Html.yml
@@ -38,7 +38,7 @@ items:
   source:
     remote:
       path: core/connectors/Html.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Html
     path: ../core/connectors/Html.cs
@@ -80,7 +80,7 @@ items:
   source:
     remote:
       path: core/connectors/Html.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: HtmlDoc
     path: ../core/connectors/Html.cs
@@ -118,7 +118,7 @@ items:
   source:
     remote:
       path: core/connectors/Html.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Raw
     path: ../core/connectors/Html.cs
@@ -156,7 +156,7 @@ items:
   source:
     remote:
       path: core/connectors/Html.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/connectors/Html.cs
@@ -192,7 +192,7 @@ items:
   source:
     remote:
       path: core/connectors/Html.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/connectors/Html.cs
@@ -235,7 +235,7 @@ items:
   source:
     remote:
       path: core/connectors/Html.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/connectors/Html.cs
@@ -276,7 +276,7 @@ items:
   source:
     remote:
       path: core/connectors/Html.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Dispose
     path: ../core/connectors/Html.cs
@@ -311,7 +311,7 @@ items:
   source:
     remote:
       path: core/connectors/Html.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ValidateHtml5AgainstW3C
     path: ../core/connectors/Html.cs
@@ -343,7 +343,7 @@ items:
   source:
     remote:
       path: core/connectors/Html.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: SelectNodes
     path: ../core/connectors/Html.cs
@@ -382,7 +382,7 @@ items:
   source:
     remote:
       path: core/connectors/Html.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: SelectNodes
     path: ../core/connectors/Html.cs
@@ -424,7 +424,7 @@ items:
   source:
     remote:
       path: core/connectors/Html.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CountNodes
     path: ../core/connectors/Html.cs
@@ -463,7 +463,7 @@ items:
   source:
     remote:
       path: core/connectors/Html.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CountNodes
     path: ../core/connectors/Html.cs
@@ -505,7 +505,7 @@ items:
   source:
     remote:
       path: core/connectors/Html.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GroupSiblings
     path: ../core/connectors/Html.cs
@@ -544,7 +544,7 @@ items:
   source:
     remote:
       path: core/connectors/Html.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GroupSiblings
     path: ../core/connectors/Html.cs
@@ -586,7 +586,7 @@ items:
   source:
     remote:
       path: core/connectors/Html.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CountSiblings
     path: ../core/connectors/Html.cs
@@ -625,7 +625,7 @@ items:
   source:
     remote:
       path: core/connectors/Html.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CountSiblings
     path: ../core/connectors/Html.cs
@@ -667,7 +667,7 @@ items:
   source:
     remote:
       path: core/connectors/Html.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ContentLength
     path: ../core/connectors/Html.cs
@@ -706,7 +706,7 @@ items:
   source:
     remote:
       path: core/connectors/Html.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ContentLength
     path: ../core/connectors/Html.cs
@@ -748,7 +748,7 @@ items:
   source:
     remote:
       path: core/connectors/Html.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetRelatedLabels
     path: ../core/connectors/Html.cs
@@ -787,7 +787,7 @@ items:
   source:
     remote:
       path: core/connectors/Html.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetRelatedLabels
     path: ../core/connectors/Html.cs
@@ -829,7 +829,7 @@ items:
   source:
     remote:
       path: core/connectors/Html.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CountRelatedLabels
     path: ../core/connectors/Html.cs
@@ -868,7 +868,7 @@ items:
   source:
     remote:
       path: core/connectors/Html.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CountRelatedLabels
     path: ../core/connectors/Html.cs
@@ -910,7 +910,7 @@ items:
   source:
     remote:
       path: core/connectors/Html.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ValidateTable
     path: ../core/connectors/Html.cs
@@ -946,7 +946,7 @@ items:
   source:
     remote:
       path: core/connectors/Html.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ValidateTable
     path: ../core/connectors/Html.cs

--- a/docs/api/AutoCheck.Core.Connectors.Math.yml
+++ b/docs/api/AutoCheck.Core.Connectors.Math.yml
@@ -17,7 +17,7 @@ items:
   source:
     remote:
       path: core/connectors/Math.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Math
     path: ../core/connectors/Math.cs
@@ -59,7 +59,7 @@ items:
   source:
     remote:
       path: core/connectors/Math.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Dispose
     path: ../core/connectors/Math.cs
@@ -94,7 +94,7 @@ items:
   source:
     remote:
       path: core/connectors/Math.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Evaluate
     path: ../core/connectors/Math.cs

--- a/docs/api/AutoCheck.Core.Connectors.Odoo.yml
+++ b/docs/api/AutoCheck.Core.Connectors.Odoo.yml
@@ -53,7 +53,7 @@ items:
   source:
     remote:
       path: core/connectors/Odoo.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Odoo
     path: ../core/connectors/Odoo.cs
@@ -133,7 +133,7 @@ items:
   source:
     remote:
       path: core/connectors/Odoo.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CompanyID
     path: ../core/connectors/Odoo.cs
@@ -171,7 +171,7 @@ items:
   source:
     remote:
       path: core/connectors/Odoo.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CompanyName
     path: ../core/connectors/Odoo.cs
@@ -209,7 +209,7 @@ items:
   source:
     remote:
       path: core/connectors/Odoo.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/connectors/Odoo.cs
@@ -259,7 +259,7 @@ items:
   source:
     remote:
       path: core/connectors/Odoo.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/connectors/Odoo.cs
@@ -309,7 +309,7 @@ items:
   source:
     remote:
       path: core/connectors/Odoo.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetCompanyID
     path: ../core/connectors/Odoo.cs
@@ -351,7 +351,7 @@ items:
   source:
     remote:
       path: core/connectors/Odoo.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetCompanyData
     path: ../core/connectors/Odoo.cs
@@ -390,7 +390,7 @@ items:
   source:
     remote:
       path: core/connectors/Odoo.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetCompanyData
     path: ../core/connectors/Odoo.cs
@@ -429,7 +429,7 @@ items:
   source:
     remote:
       path: core/connectors/Odoo.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetProviderID
     path: ../core/connectors/Odoo.cs
@@ -471,7 +471,7 @@ items:
   source:
     remote:
       path: core/connectors/Odoo.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetProviderData
     path: ../core/connectors/Odoo.cs
@@ -510,7 +510,7 @@ items:
   source:
     remote:
       path: core/connectors/Odoo.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetProviderData
     path: ../core/connectors/Odoo.cs
@@ -549,7 +549,7 @@ items:
   source:
     remote:
       path: core/connectors/Odoo.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetProductTemplateID
     path: ../core/connectors/Odoo.cs
@@ -591,7 +591,7 @@ items:
   source:
     remote:
       path: core/connectors/Odoo.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetProductTemplateData
     path: ../core/connectors/Odoo.cs
@@ -630,7 +630,7 @@ items:
   source:
     remote:
       path: core/connectors/Odoo.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetProductTemplateData
     path: ../core/connectors/Odoo.cs
@@ -669,7 +669,7 @@ items:
   source:
     remote:
       path: core/connectors/Odoo.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetLastPurchaseID
     path: ../core/connectors/Odoo.cs
@@ -704,7 +704,7 @@ items:
   source:
     remote:
       path: core/connectors/Odoo.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetPurchaseID
     path: ../core/connectors/Odoo.cs
@@ -743,7 +743,7 @@ items:
   source:
     remote:
       path: core/connectors/Odoo.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetPurchaseCode
     path: ../core/connectors/Odoo.cs
@@ -782,7 +782,7 @@ items:
   source:
     remote:
       path: core/connectors/Odoo.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetPurchaseData
     path: ../core/connectors/Odoo.cs
@@ -821,7 +821,7 @@ items:
   source:
     remote:
       path: core/connectors/Odoo.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetPurchaseData
     path: ../core/connectors/Odoo.cs
@@ -860,7 +860,7 @@ items:
   source:
     remote:
       path: core/connectors/Odoo.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetLastSaleID
     path: ../core/connectors/Odoo.cs
@@ -895,7 +895,7 @@ items:
   source:
     remote:
       path: core/connectors/Odoo.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetSaleID
     path: ../core/connectors/Odoo.cs
@@ -934,7 +934,7 @@ items:
   source:
     remote:
       path: core/connectors/Odoo.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetSaleCode
     path: ../core/connectors/Odoo.cs
@@ -973,7 +973,7 @@ items:
   source:
     remote:
       path: core/connectors/Odoo.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetSaleData
     path: ../core/connectors/Odoo.cs
@@ -1012,7 +1012,7 @@ items:
   source:
     remote:
       path: core/connectors/Odoo.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetSaleData
     path: ../core/connectors/Odoo.cs
@@ -1051,7 +1051,7 @@ items:
   source:
     remote:
       path: core/connectors/Odoo.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetLastPosSaleID
     path: ../core/connectors/Odoo.cs
@@ -1086,7 +1086,7 @@ items:
   source:
     remote:
       path: core/connectors/Odoo.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetPosSaleID
     path: ../core/connectors/Odoo.cs
@@ -1125,7 +1125,7 @@ items:
   source:
     remote:
       path: core/connectors/Odoo.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetPosSaleCode
     path: ../core/connectors/Odoo.cs
@@ -1164,7 +1164,7 @@ items:
   source:
     remote:
       path: core/connectors/Odoo.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetPosSaleData
     path: ../core/connectors/Odoo.cs
@@ -1202,7 +1202,7 @@ items:
   source:
     remote:
       path: core/connectors/Odoo.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetPosSaleData
     path: ../core/connectors/Odoo.cs
@@ -1240,7 +1240,7 @@ items:
   source:
     remote:
       path: core/connectors/Odoo.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetStockMovementData
     path: ../core/connectors/Odoo.cs
@@ -1282,7 +1282,7 @@ items:
   source:
     remote:
       path: core/connectors/Odoo.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetScrappedStockData
     path: ../core/connectors/Odoo.cs
@@ -1317,7 +1317,7 @@ items:
   source:
     remote:
       path: core/connectors/Odoo.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetInvoiceID
     path: ../core/connectors/Odoo.cs
@@ -1356,7 +1356,7 @@ items:
   source:
     remote:
       path: core/connectors/Odoo.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetInvoiceCode
     path: ../core/connectors/Odoo.cs
@@ -1395,7 +1395,7 @@ items:
   source:
     remote:
       path: core/connectors/Odoo.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetInvoiceData
     path: ../core/connectors/Odoo.cs
@@ -1434,7 +1434,7 @@ items:
   source:
     remote:
       path: core/connectors/Odoo.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetInvoiceData
     path: ../core/connectors/Odoo.cs
@@ -1473,7 +1473,7 @@ items:
   source:
     remote:
       path: core/connectors/Odoo.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetUserID
     path: ../core/connectors/Odoo.cs
@@ -1515,7 +1515,7 @@ items:
   source:
     remote:
       path: core/connectors/Odoo.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetUserName
     path: ../core/connectors/Odoo.cs
@@ -1554,7 +1554,7 @@ items:
   source:
     remote:
       path: core/connectors/Odoo.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetUserData
     path: ../core/connectors/Odoo.cs
@@ -1593,7 +1593,7 @@ items:
   source:
     remote:
       path: core/connectors/Odoo.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetUserData
     path: ../core/connectors/Odoo.cs

--- a/docs/api/AutoCheck.Core.Connectors.Operator.yml
+++ b/docs/api/AutoCheck.Core.Connectors.Operator.yml
@@ -22,7 +22,7 @@ items:
   source:
     remote:
       path: core/connectors/Base.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Operator
     path: ../core/connectors/Base.cs
@@ -57,7 +57,7 @@ items:
   source:
     remote:
       path: core/connectors/Base.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: LOWER
     path: ../core/connectors/Base.cs
@@ -90,7 +90,7 @@ items:
   source:
     remote:
       path: core/connectors/Base.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: LOWEREQUALS
     path: ../core/connectors/Base.cs
@@ -123,7 +123,7 @@ items:
   source:
     remote:
       path: core/connectors/Base.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GREATER
     path: ../core/connectors/Base.cs
@@ -156,7 +156,7 @@ items:
   source:
     remote:
       path: core/connectors/Base.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GREATEREQUALS
     path: ../core/connectors/Base.cs
@@ -189,7 +189,7 @@ items:
   source:
     remote:
       path: core/connectors/Base.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: EQUALS
     path: ../core/connectors/Base.cs
@@ -222,7 +222,7 @@ items:
   source:
     remote:
       path: core/connectors/Base.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: NOTEQUALS
     path: ../core/connectors/Base.cs
@@ -255,7 +255,7 @@ items:
   source:
     remote:
       path: core/connectors/Base.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: LIKE
     path: ../core/connectors/Base.cs

--- a/docs/api/AutoCheck.Core.Connectors.PlainText.PlainTextDocument.yml
+++ b/docs/api/AutoCheck.Core.Connectors.PlainText.PlainTextDocument.yml
@@ -19,7 +19,7 @@ items:
   source:
     remote:
       path: core/connectors/PlainText.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: PlainTextDocument
     path: ../core/connectors/PlainText.cs
@@ -58,7 +58,7 @@ items:
   source:
     remote:
       path: core/connectors/PlainText.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Content
     path: ../core/connectors/PlainText.cs
@@ -95,7 +95,7 @@ items:
   source:
     remote:
       path: core/connectors/PlainText.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Lines
     path: ../core/connectors/PlainText.cs
@@ -132,7 +132,7 @@ items:
   source:
     remote:
       path: core/connectors/PlainText.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/connectors/PlainText.cs
@@ -168,7 +168,7 @@ items:
   source:
     remote:
       path: core/connectors/PlainText.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetLine
     path: ../core/connectors/PlainText.cs

--- a/docs/api/AutoCheck.Core.Connectors.PlainText.yml
+++ b/docs/api/AutoCheck.Core.Connectors.PlainText.yml
@@ -22,7 +22,7 @@ items:
   source:
     remote:
       path: core/connectors/PlainText.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: PlainText
     path: ../core/connectors/PlainText.cs
@@ -64,7 +64,7 @@ items:
   source:
     remote:
       path: core/connectors/PlainText.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: plainTextDoc
     path: ../core/connectors/PlainText.cs
@@ -102,7 +102,7 @@ items:
   source:
     remote:
       path: core/connectors/PlainText.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/connectors/PlainText.cs
@@ -138,7 +138,7 @@ items:
   source:
     remote:
       path: core/connectors/PlainText.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/connectors/PlainText.cs
@@ -181,7 +181,7 @@ items:
   source:
     remote:
       path: core/connectors/PlainText.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/connectors/PlainText.cs
@@ -222,7 +222,7 @@ items:
   source:
     remote:
       path: core/connectors/PlainText.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Dispose
     path: ../core/connectors/PlainText.cs
@@ -257,7 +257,7 @@ items:
   source:
     remote:
       path: core/connectors/PlainText.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Find
     path: ../core/connectors/PlainText.cs
@@ -296,7 +296,7 @@ items:
   source:
     remote:
       path: core/connectors/PlainText.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Count
     path: ../core/connectors/PlainText.cs

--- a/docs/api/AutoCheck.Core.Connectors.Postgres.yml
+++ b/docs/api/AutoCheck.Core.Connectors.Postgres.yml
@@ -53,7 +53,7 @@ items:
   source:
     remote:
       path: core/connectors/Postgres.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Postgres
     path: ../core/connectors/Postgres.cs
@@ -97,7 +97,7 @@ items:
   source:
     remote:
       path: core/connectors/Postgres.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Conn
     path: ../core/connectors/Postgres.cs
@@ -135,7 +135,7 @@ items:
   source:
     remote:
       path: core/connectors/Postgres.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Host
     path: ../core/connectors/Postgres.cs
@@ -173,7 +173,7 @@ items:
   source:
     remote:
       path: core/connectors/Postgres.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Database
     path: ../core/connectors/Postgres.cs
@@ -211,7 +211,7 @@ items:
   source:
     remote:
       path: core/connectors/Postgres.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: User
     path: ../core/connectors/Postgres.cs
@@ -249,7 +249,7 @@ items:
   source:
     remote:
       path: core/connectors/Postgres.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Password
     path: ../core/connectors/Postgres.cs
@@ -287,7 +287,7 @@ items:
   source:
     remote:
       path: core/connectors/Postgres.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: BinPath
     path: ../core/connectors/Postgres.cs
@@ -325,7 +325,7 @@ items:
   source:
     remote:
       path: core/connectors/Postgres.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/connectors/Postgres.cs
@@ -373,7 +373,7 @@ items:
   source:
     remote:
       path: core/connectors/Postgres.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Dispose
     path: ../core/connectors/Postgres.cs
@@ -408,7 +408,7 @@ items:
   source:
     remote:
       path: core/connectors/Postgres.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: TestConnection
     path: ../core/connectors/Postgres.cs
@@ -440,7 +440,7 @@ items:
   source:
     remote:
       path: core/connectors/Postgres.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ExecuteQuery
     path: ../core/connectors/Postgres.cs
@@ -479,7 +479,7 @@ items:
   source:
     remote:
       path: core/connectors/Postgres.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ExecuteNonQuery
     path: ../core/connectors/Postgres.cs
@@ -515,7 +515,7 @@ items:
   source:
     remote:
       path: core/connectors/Postgres.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ExecuteScalar
     path: ../core/connectors/Postgres.cs
@@ -559,7 +559,7 @@ items:
   source:
     remote:
       path: core/connectors/Postgres.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ExistsDataBase
     path: ../core/connectors/Postgres.cs
@@ -594,7 +594,7 @@ items:
   source:
     remote:
       path: core/connectors/Postgres.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CreateDataBase
     path: ../core/connectors/Postgres.cs
@@ -632,7 +632,7 @@ items:
   source:
     remote:
       path: core/connectors/Postgres.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CreateDataBase
     path: ../core/connectors/Postgres.cs
@@ -668,7 +668,7 @@ items:
   source:
     remote:
       path: core/connectors/Postgres.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ImportSqlDump
     path: ../core/connectors/Postgres.cs
@@ -704,7 +704,7 @@ items:
   source:
     remote:
       path: core/connectors/Postgres.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: DropDataBase
     path: ../core/connectors/Postgres.cs
@@ -736,7 +736,7 @@ items:
   source:
     remote:
       path: core/connectors/Postgres.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetUsers
     path: ../core/connectors/Postgres.cs
@@ -771,7 +771,7 @@ items:
   source:
     remote:
       path: core/connectors/Postgres.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CountUsers
     path: ../core/connectors/Postgres.cs
@@ -806,7 +806,7 @@ items:
   source:
     remote:
       path: core/connectors/Postgres.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CreateUser
     path: ../core/connectors/Postgres.cs
@@ -843,7 +843,7 @@ items:
   source:
     remote:
       path: core/connectors/Postgres.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: DropUser
     path: ../core/connectors/Postgres.cs
@@ -878,7 +878,7 @@ items:
   source:
     remote:
       path: core/connectors/Postgres.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ExistsUser
     path: ../core/connectors/Postgres.cs
@@ -913,7 +913,7 @@ items:
   source:
     remote:
       path: core/connectors/Postgres.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: DropUserMembership
     path: ../core/connectors/Postgres.cs
@@ -949,7 +949,7 @@ items:
   source:
     remote:
       path: core/connectors/Postgres.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetRoles
     path: ../core/connectors/Postgres.cs
@@ -984,7 +984,7 @@ items:
   source:
     remote:
       path: core/connectors/Postgres.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CountRoles
     path: ../core/connectors/Postgres.cs
@@ -1019,7 +1019,7 @@ items:
   source:
     remote:
       path: core/connectors/Postgres.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CreateRole
     path: ../core/connectors/Postgres.cs
@@ -1055,7 +1055,7 @@ items:
   source:
     remote:
       path: core/connectors/Postgres.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: DropRole
     path: ../core/connectors/Postgres.cs
@@ -1091,7 +1091,7 @@ items:
   source:
     remote:
       path: core/connectors/Postgres.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ExistsRole
     path: ../core/connectors/Postgres.cs
@@ -1126,7 +1126,7 @@ items:
   source:
     remote:
       path: core/connectors/Postgres.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: DropRoleMembership
     path: ../core/connectors/Postgres.cs
@@ -1162,7 +1162,7 @@ items:
   source:
     remote:
       path: core/connectors/Postgres.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetMembership
     path: ../core/connectors/Postgres.cs
@@ -1201,7 +1201,7 @@ items:
   source:
     remote:
       path: core/connectors/Postgres.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetTablePrivileges
     path: ../core/connectors/Postgres.cs
@@ -1246,7 +1246,7 @@ items:
   source:
     remote:
       path: core/connectors/Postgres.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetSchemaPrivileges
     path: ../core/connectors/Postgres.cs
@@ -1288,7 +1288,7 @@ items:
   source:
     remote:
       path: core/connectors/Postgres.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CompareSelectWithView
     path: ../core/connectors/Postgres.cs
@@ -1333,7 +1333,7 @@ items:
   source:
     remote:
       path: core/connectors/Postgres.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CompareSelects
     path: ../core/connectors/Postgres.cs
@@ -1375,7 +1375,7 @@ items:
   source:
     remote:
       path: core/connectors/Postgres.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetViewDefinition
     path: ../core/connectors/Postgres.cs
@@ -1417,7 +1417,7 @@ items:
   source:
     remote:
       path: core/connectors/Postgres.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetForeignKeys
     path: ../core/connectors/Postgres.cs
@@ -1459,7 +1459,7 @@ items:
   source:
     remote:
       path: core/connectors/Postgres.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ExistsForeignKey
     path: ../core/connectors/Postgres.cs
@@ -1513,7 +1513,7 @@ items:
   source:
     remote:
       path: core/connectors/Postgres.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ExistsTable
     path: ../core/connectors/Postgres.cs

--- a/docs/api/AutoCheck.Core.Connectors.Rss.yml
+++ b/docs/api/AutoCheck.Core.Connectors.Rss.yml
@@ -20,7 +20,7 @@ items:
   source:
     remote:
       path: core/connectors/Rss.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Rss
     path: ../core/connectors/Rss.cs
@@ -74,7 +74,7 @@ items:
   source:
     remote:
       path: core/connectors/Rss.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/connectors/Rss.cs
@@ -110,7 +110,7 @@ items:
   source:
     remote:
       path: core/connectors/Rss.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/connectors/Rss.cs
@@ -153,7 +153,7 @@ items:
   source:
     remote:
       path: core/connectors/Rss.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/connectors/Rss.cs
@@ -194,7 +194,7 @@ items:
   source:
     remote:
       path: core/connectors/Rss.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Dispose
     path: ../core/connectors/Rss.cs
@@ -229,7 +229,7 @@ items:
   source:
     remote:
       path: core/connectors/Rss.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ValidateRssAgainstW3C
     path: ../core/connectors/Rss.cs

--- a/docs/api/AutoCheck.Core.Connectors.Shell.yml
+++ b/docs/api/AutoCheck.Core.Connectors.Shell.yml
@@ -45,7 +45,7 @@ items:
   source:
     remote:
       path: core/connectors/Shell.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Shell
     path: ../core/connectors/Shell.cs
@@ -87,7 +87,7 @@ items:
   source:
     remote:
       path: core/connectors/Shell.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: RemoteOS
     path: ../core/connectors/Shell.cs
@@ -125,7 +125,7 @@ items:
   source:
     remote:
       path: core/connectors/Shell.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Host
     path: ../core/connectors/Shell.cs
@@ -163,7 +163,7 @@ items:
   source:
     remote:
       path: core/connectors/Shell.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Username
     path: ../core/connectors/Shell.cs
@@ -201,7 +201,7 @@ items:
   source:
     remote:
       path: core/connectors/Shell.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Password
     path: ../core/connectors/Shell.cs
@@ -239,7 +239,7 @@ items:
   source:
     remote:
       path: core/connectors/Shell.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Port
     path: ../core/connectors/Shell.cs
@@ -277,7 +277,7 @@ items:
   source:
     remote:
       path: core/connectors/Shell.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: IsLocal
     path: ../core/connectors/Shell.cs
@@ -315,7 +315,7 @@ items:
   source:
     remote:
       path: core/connectors/Shell.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: IsRemote
     path: ../core/connectors/Shell.cs
@@ -353,7 +353,7 @@ items:
   source:
     remote:
       path: core/connectors/Shell.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/connectors/Shell.cs
@@ -385,7 +385,7 @@ items:
   source:
     remote:
       path: core/connectors/Shell.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/connectors/Shell.cs
@@ -426,7 +426,7 @@ items:
   source:
     remote:
       path: core/connectors/Shell.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/connectors/Shell.cs
@@ -467,7 +467,7 @@ items:
   source:
     remote:
       path: core/connectors/Shell.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Dispose
     path: ../core/connectors/Shell.cs
@@ -502,7 +502,7 @@ items:
   source:
     remote:
       path: core/connectors/Shell.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: TestConnection
     path: ../core/connectors/Shell.cs
@@ -534,7 +534,7 @@ items:
   source:
     remote:
       path: core/connectors/Shell.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: RunCommand
     path: ../core/connectors/Shell.cs
@@ -575,7 +575,7 @@ items:
   source:
     remote:
       path: core/connectors/Shell.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetFolder
     path: ../core/connectors/Shell.cs
@@ -622,7 +622,7 @@ items:
   source:
     remote:
       path: core/connectors/Shell.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetFile
     path: ../core/connectors/Shell.cs
@@ -669,7 +669,7 @@ items:
   source:
     remote:
       path: core/connectors/Shell.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetFolders
     path: ../core/connectors/Shell.cs
@@ -713,7 +713,7 @@ items:
   source:
     remote:
       path: core/connectors/Shell.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetFolders
     path: ../core/connectors/Shell.cs
@@ -758,7 +758,7 @@ items:
   source:
     remote:
       path: core/connectors/Shell.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetFiles
     path: ../core/connectors/Shell.cs
@@ -802,7 +802,7 @@ items:
   source:
     remote:
       path: core/connectors/Shell.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetFiles
     path: ../core/connectors/Shell.cs
@@ -847,7 +847,7 @@ items:
   source:
     remote:
       path: core/connectors/Shell.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CountFolders
     path: ../core/connectors/Shell.cs
@@ -892,7 +892,7 @@ items:
   source:
     remote:
       path: core/connectors/Shell.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CountFolders
     path: ../core/connectors/Shell.cs
@@ -936,7 +936,7 @@ items:
   source:
     remote:
       path: core/connectors/Shell.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CountFiles
     path: ../core/connectors/Shell.cs
@@ -981,7 +981,7 @@ items:
   source:
     remote:
       path: core/connectors/Shell.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CountFiles
     path: ../core/connectors/Shell.cs
@@ -1025,7 +1025,7 @@ items:
   source:
     remote:
       path: core/connectors/Shell.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ExistsFolder
     path: ../core/connectors/Shell.cs
@@ -1063,7 +1063,7 @@ items:
   source:
     remote:
       path: core/connectors/Shell.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ExistsFolder
     path: ../core/connectors/Shell.cs
@@ -1108,7 +1108,7 @@ items:
   source:
     remote:
       path: core/connectors/Shell.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ExistsFile
     path: ../core/connectors/Shell.cs
@@ -1146,7 +1146,7 @@ items:
   source:
     remote:
       path: core/connectors/Shell.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ExistsFile
     path: ../core/connectors/Shell.cs
@@ -1191,7 +1191,7 @@ items:
   source:
     remote:
       path: core/connectors/Shell.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: DownloadFile
     path: ../core/connectors/Shell.cs
@@ -1233,7 +1233,7 @@ items:
   source:
     remote:
       path: core/connectors/Shell.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: DownloadFolder
     path: ../core/connectors/Shell.cs
@@ -1275,7 +1275,7 @@ items:
   source:
     remote:
       path: core/connectors/Shell.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: DownloadFolder
     path: ../core/connectors/Shell.cs

--- a/docs/api/AutoCheck.Core.Connectors.Xml.XmlNodeType.yml
+++ b/docs/api/AutoCheck.Core.Connectors.Xml.XmlNodeType.yml
@@ -19,7 +19,7 @@ items:
   source:
     remote:
       path: core/connectors/Xml.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: XmlNodeType
     path: ../core/connectors/Xml.cs
@@ -52,7 +52,7 @@ items:
   source:
     remote:
       path: core/connectors/Xml.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ALL
     path: ../core/connectors/Xml.cs
@@ -84,7 +84,7 @@ items:
   source:
     remote:
       path: core/connectors/Xml.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: STRING
     path: ../core/connectors/Xml.cs
@@ -116,7 +116,7 @@ items:
   source:
     remote:
       path: core/connectors/Xml.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: BOOLEAN
     path: ../core/connectors/Xml.cs
@@ -148,7 +148,7 @@ items:
   source:
     remote:
       path: core/connectors/Xml.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: NUMERIC
     path: ../core/connectors/Xml.cs

--- a/docs/api/AutoCheck.Core.Connectors.Xml.yml
+++ b/docs/api/AutoCheck.Core.Connectors.Xml.yml
@@ -28,7 +28,7 @@ items:
   source:
     remote:
       path: core/connectors/Xml.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Xml
     path: ../core/connectors/Xml.cs
@@ -72,7 +72,7 @@ items:
   source:
     remote:
       path: core/connectors/Xml.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Comments
     path: ../core/connectors/Xml.cs
@@ -107,7 +107,7 @@ items:
   source:
     remote:
       path: core/connectors/Xml.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: XmlDoc
     path: ../core/connectors/Xml.cs
@@ -145,7 +145,7 @@ items:
   source:
     remote:
       path: core/connectors/Xml.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Raw
     path: ../core/connectors/Xml.cs
@@ -183,7 +183,7 @@ items:
   source:
     remote:
       path: core/connectors/Xml.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/connectors/Xml.cs
@@ -222,7 +222,7 @@ items:
   source:
     remote:
       path: core/connectors/Xml.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/connectors/Xml.cs
@@ -267,7 +267,7 @@ items:
   source:
     remote:
       path: core/connectors/Xml.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/connectors/Xml.cs
@@ -310,7 +310,7 @@ items:
   source:
     remote:
       path: core/connectors/Xml.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Dispose
     path: ../core/connectors/Xml.cs
@@ -345,7 +345,7 @@ items:
   source:
     remote:
       path: core/connectors/Xml.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: SelectNodes
     path: ../core/connectors/Xml.cs
@@ -386,7 +386,7 @@ items:
   source:
     remote:
       path: core/connectors/Xml.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: SelectNodes
     path: ../core/connectors/Xml.cs
@@ -430,7 +430,7 @@ items:
   source:
     remote:
       path: core/connectors/Xml.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CountNodes
     path: ../core/connectors/Xml.cs
@@ -471,7 +471,7 @@ items:
   source:
     remote:
       path: core/connectors/Xml.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CountNodes
     path: ../core/connectors/Xml.cs
@@ -515,7 +515,7 @@ items:
   source:
     remote:
       path: core/connectors/Xml.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Equals
     path: ../core/connectors/Xml.cs
@@ -556,7 +556,7 @@ items:
   source:
     remote:
       path: core/connectors/Xml.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Equals
     path: ../core/connectors/Xml.cs

--- a/docs/api/AutoCheck.Core.Connectors.Zip.yml
+++ b/docs/api/AutoCheck.Core.Connectors.Zip.yml
@@ -22,7 +22,7 @@ items:
   source:
     remote:
       path: core/connectors/Zip.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Zip
     path: ../core/connectors/Zip.cs
@@ -62,7 +62,7 @@ items:
   source:
     remote:
       path: core/connectors/Zip.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ZipFile
     path: ../core/connectors/Zip.cs
@@ -97,7 +97,7 @@ items:
   source:
     remote:
       path: core/connectors/Zip.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/connectors/Zip.cs
@@ -133,7 +133,7 @@ items:
   source:
     remote:
       path: core/connectors/Zip.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/connectors/Zip.cs
@@ -174,7 +174,7 @@ items:
   source:
     remote:
       path: core/connectors/Zip.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/connectors/Zip.cs
@@ -217,7 +217,7 @@ items:
   source:
     remote:
       path: core/connectors/Zip.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Dispose
     path: ../core/connectors/Zip.cs
@@ -252,7 +252,7 @@ items:
   source:
     remote:
       path: core/connectors/Zip.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Extract
     path: ../core/connectors/Zip.cs
@@ -291,7 +291,7 @@ items:
   source:
     remote:
       path: core/connectors/Zip.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Extract
     path: ../core/connectors/Zip.cs

--- a/docs/api/AutoCheck.Core.CopyDetectors.Base.yml
+++ b/docs/api/AutoCheck.Core.CopyDetectors.Base.yml
@@ -27,7 +27,7 @@ items:
   source:
     remote:
       path: core/copy/Base.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Base
     path: ../core/copy/Base.cs
@@ -70,7 +70,7 @@ items:
   source:
     remote:
       path: core/copy/Base.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Threshold
     path: ../core/copy/Base.cs
@@ -110,7 +110,7 @@ items:
   source:
     remote:
       path: core/copy/Base.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: FilePattern
     path: ../core/copy/Base.cs
@@ -150,7 +150,7 @@ items:
   source:
     remote:
       path: core/copy/Base.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Count
     path: ../core/copy/Base.cs
@@ -190,7 +190,7 @@ items:
   source:
     remote:
       path: core/copy/Base.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/copy/Base.cs
@@ -227,7 +227,7 @@ items:
   source:
     remote:
       path: core/copy/Base.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Dispose
     path: ../core/copy/Base.cs
@@ -261,7 +261,7 @@ items:
   source:
     remote:
       path: core/copy/Base.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Load
     path: ../core/copy/Base.cs
@@ -299,7 +299,7 @@ items:
   source:
     remote:
       path: core/copy/Base.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Load
     path: ../core/copy/Base.cs
@@ -347,7 +347,7 @@ items:
   source:
     remote:
       path: core/copy/Base.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Load
     path: ../core/copy/Base.cs
@@ -398,7 +398,7 @@ items:
   source:
     remote:
       path: core/copy/Base.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Load
     path: ../core/copy/Base.cs
@@ -439,7 +439,7 @@ items:
   source:
     remote:
       path: core/copy/Base.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Compare
     path: ../core/copy/Base.cs
@@ -473,7 +473,7 @@ items:
   source:
     remote:
       path: core/copy/Base.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CopyDetected
     path: ../core/copy/Base.cs
@@ -514,7 +514,7 @@ items:
   source:
     remote:
       path: core/copy/Base.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetDetails
     path: ../core/copy/Base.cs

--- a/docs/api/AutoCheck.Core.CopyDetectors.Css.yml
+++ b/docs/api/AutoCheck.Core.CopyDetectors.Css.yml
@@ -16,7 +16,7 @@ items:
   source:
     remote:
       path: core/copy/Css.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Css
     path: ../core/copy/Css.cs
@@ -72,7 +72,7 @@ items:
   source:
     remote:
       path: core/copy/Css.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/copy/Css.cs

--- a/docs/api/AutoCheck.Core.CopyDetectors.Html.yml
+++ b/docs/api/AutoCheck.Core.CopyDetectors.Html.yml
@@ -16,7 +16,7 @@ items:
   source:
     remote:
       path: core/copy/Html.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Html
     path: ../core/copy/Html.cs
@@ -72,7 +72,7 @@ items:
   source:
     remote:
       path: core/copy/Html.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/copy/Html.cs

--- a/docs/api/AutoCheck.Core.CopyDetectors.PlainText.yml
+++ b/docs/api/AutoCheck.Core.CopyDetectors.PlainText.yml
@@ -25,7 +25,7 @@ items:
   source:
     remote:
       path: core/copy/PlainText.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: PlainText
     path: ../core/copy/PlainText.cs
@@ -76,7 +76,7 @@ items:
   source:
     remote:
       path: core/copy/PlainText.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: WordsAmountWeight
     path: ../core/copy/PlainText.cs
@@ -114,7 +114,7 @@ items:
   source:
     remote:
       path: core/copy/PlainText.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: WordCountWeight
     path: ../core/copy/PlainText.cs
@@ -152,7 +152,7 @@ items:
   source:
     remote:
       path: core/copy/PlainText.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: LineCountWeight
     path: ../core/copy/PlainText.cs
@@ -190,7 +190,7 @@ items:
   source:
     remote:
       path: core/copy/PlainText.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Count
     path: ../core/copy/PlainText.cs
@@ -231,7 +231,7 @@ items:
   source:
     remote:
       path: core/copy/PlainText.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/copy/PlainText.cs
@@ -268,7 +268,7 @@ items:
   source:
     remote:
       path: core/copy/PlainText.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Dispose
     path: ../core/copy/PlainText.cs
@@ -303,7 +303,7 @@ items:
   source:
     remote:
       path: core/copy/PlainText.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Load
     path: ../core/copy/PlainText.cs
@@ -345,7 +345,7 @@ items:
   source:
     remote:
       path: core/copy/PlainText.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Compare
     path: ../core/copy/PlainText.cs
@@ -380,7 +380,7 @@ items:
   source:
     remote:
       path: core/copy/PlainText.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CopyDetected
     path: ../core/copy/PlainText.cs
@@ -421,7 +421,7 @@ items:
   source:
     remote:
       path: core/copy/PlainText.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetDetails
     path: ../core/copy/PlainText.cs

--- a/docs/api/AutoCheck.Core.CopyDetectors.SqlLog.yml
+++ b/docs/api/AutoCheck.Core.CopyDetectors.SqlLog.yml
@@ -16,7 +16,7 @@ items:
   source:
     remote:
       path: core/copy/SqlLog.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: SqlLog
     path: ../core/copy/SqlLog.cs
@@ -72,7 +72,7 @@ items:
   source:
     remote:
       path: core/copy/SqlLog.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/copy/SqlLog.cs

--- a/docs/api/AutoCheck.Core.CopyDetectors.Xml.yml
+++ b/docs/api/AutoCheck.Core.CopyDetectors.Xml.yml
@@ -16,7 +16,7 @@ items:
   source:
     remote:
       path: core/copy/Xml.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Xml
     path: ../core/copy/Xml.cs
@@ -72,7 +72,7 @@ items:
   source:
     remote:
       path: core/copy/Xml.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/copy/Xml.cs

--- a/docs/api/AutoCheck.Core.Exceptions.ArgumentInvalidException.yml
+++ b/docs/api/AutoCheck.Core.Exceptions.ArgumentInvalidException.yml
@@ -17,7 +17,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ArgumentInvalidException
     path: ../core/main/Exceptions.cs
@@ -54,7 +54,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/main/Exceptions.cs
@@ -84,7 +84,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/main/Exceptions.cs

--- a/docs/api/AutoCheck.Core.Exceptions.ArgumentNotFoundException.yml
+++ b/docs/api/AutoCheck.Core.Exceptions.ArgumentNotFoundException.yml
@@ -17,7 +17,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ArgumentNotFoundException
     path: ../core/main/Exceptions.cs
@@ -55,7 +55,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/main/Exceptions.cs
@@ -85,7 +85,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/main/Exceptions.cs

--- a/docs/api/AutoCheck.Core.Exceptions.ConnectionInvalidException.yml
+++ b/docs/api/AutoCheck.Core.Exceptions.ConnectionInvalidException.yml
@@ -17,7 +17,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ConnectionInvalidException
     path: ../core/main/Exceptions.cs
@@ -54,7 +54,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/main/Exceptions.cs
@@ -84,7 +84,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/main/Exceptions.cs

--- a/docs/api/AutoCheck.Core.Exceptions.ConnectorInvalidException.yml
+++ b/docs/api/AutoCheck.Core.Exceptions.ConnectorInvalidException.yml
@@ -17,7 +17,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ConnectorInvalidException
     path: ../core/main/Exceptions.cs
@@ -54,7 +54,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/main/Exceptions.cs
@@ -84,7 +84,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/main/Exceptions.cs

--- a/docs/api/AutoCheck.Core.Exceptions.ConnectorNotFoundException.yml
+++ b/docs/api/AutoCheck.Core.Exceptions.ConnectorNotFoundException.yml
@@ -17,7 +17,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ConnectorNotFoundException
     path: ../core/main/Exceptions.cs
@@ -55,7 +55,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/main/Exceptions.cs
@@ -85,7 +85,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/main/Exceptions.cs

--- a/docs/api/AutoCheck.Core.Exceptions.DocumentInvalidException.yml
+++ b/docs/api/AutoCheck.Core.Exceptions.DocumentInvalidException.yml
@@ -17,7 +17,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: DocumentInvalidException
     path: ../core/main/Exceptions.cs
@@ -54,7 +54,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/main/Exceptions.cs
@@ -84,7 +84,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/main/Exceptions.cs

--- a/docs/api/AutoCheck.Core.Exceptions.DownloadFailedException.yml
+++ b/docs/api/AutoCheck.Core.Exceptions.DownloadFailedException.yml
@@ -17,7 +17,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: DownloadFailedException
     path: ../core/main/Exceptions.cs
@@ -54,7 +54,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/main/Exceptions.cs
@@ -84,7 +84,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/main/Exceptions.cs

--- a/docs/api/AutoCheck.Core.Exceptions.ItemNotFoundException.yml
+++ b/docs/api/AutoCheck.Core.Exceptions.ItemNotFoundException.yml
@@ -17,7 +17,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ItemNotFoundException
     path: ../core/main/Exceptions.cs
@@ -59,7 +59,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/main/Exceptions.cs
@@ -89,7 +89,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/main/Exceptions.cs

--- a/docs/api/AutoCheck.Core.Exceptions.PorpertyNotFoundException.yml
+++ b/docs/api/AutoCheck.Core.Exceptions.PorpertyNotFoundException.yml
@@ -17,7 +17,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: PorpertyNotFoundException
     path: ../core/main/Exceptions.cs
@@ -55,7 +55,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/main/Exceptions.cs
@@ -85,7 +85,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/main/Exceptions.cs

--- a/docs/api/AutoCheck.Core.Exceptions.QueryInvalidException.yml
+++ b/docs/api/AutoCheck.Core.Exceptions.QueryInvalidException.yml
@@ -17,7 +17,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: QueryInvalidException
     path: ../core/main/Exceptions.cs
@@ -54,7 +54,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/main/Exceptions.cs
@@ -84,7 +84,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/main/Exceptions.cs

--- a/docs/api/AutoCheck.Core.Exceptions.RegexInvalidException.yml
+++ b/docs/api/AutoCheck.Core.Exceptions.RegexInvalidException.yml
@@ -17,7 +17,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: RegexInvalidException
     path: ../core/main/Exceptions.cs
@@ -54,7 +54,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/main/Exceptions.cs
@@ -84,7 +84,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/main/Exceptions.cs

--- a/docs/api/AutoCheck.Core.Exceptions.ResultMismatchException.yml
+++ b/docs/api/AutoCheck.Core.Exceptions.ResultMismatchException.yml
@@ -17,7 +17,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ResultMismatchException
     path: ../core/main/Exceptions.cs
@@ -54,7 +54,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/main/Exceptions.cs
@@ -84,7 +84,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/main/Exceptions.cs

--- a/docs/api/AutoCheck.Core.Exceptions.StyleInvalidException.yml
+++ b/docs/api/AutoCheck.Core.Exceptions.StyleInvalidException.yml
@@ -17,7 +17,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: StyleInvalidException
     path: ../core/main/Exceptions.cs
@@ -54,7 +54,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/main/Exceptions.cs
@@ -84,7 +84,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/main/Exceptions.cs

--- a/docs/api/AutoCheck.Core.Exceptions.StyleNotAppliedException.yml
+++ b/docs/api/AutoCheck.Core.Exceptions.StyleNotAppliedException.yml
@@ -17,7 +17,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: StyleNotAppliedException
     path: ../core/main/Exceptions.cs
@@ -54,7 +54,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/main/Exceptions.cs
@@ -84,7 +84,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/main/Exceptions.cs

--- a/docs/api/AutoCheck.Core.Exceptions.StyleNotFoundException.yml
+++ b/docs/api/AutoCheck.Core.Exceptions.StyleNotFoundException.yml
@@ -17,7 +17,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: StyleNotFoundException
     path: ../core/main/Exceptions.cs
@@ -54,7 +54,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/main/Exceptions.cs
@@ -84,7 +84,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/main/Exceptions.cs

--- a/docs/api/AutoCheck.Core.Exceptions.TableInconsistencyException.yml
+++ b/docs/api/AutoCheck.Core.Exceptions.TableInconsistencyException.yml
@@ -17,7 +17,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: TableInconsistencyException
     path: ../core/main/Exceptions.cs
@@ -54,7 +54,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/main/Exceptions.cs
@@ -84,7 +84,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/main/Exceptions.cs

--- a/docs/api/AutoCheck.Core.Exceptions.VariableInvalidException.yml
+++ b/docs/api/AutoCheck.Core.Exceptions.VariableInvalidException.yml
@@ -17,7 +17,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: VariableInvalidException
     path: ../core/main/Exceptions.cs
@@ -54,7 +54,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/main/Exceptions.cs
@@ -84,7 +84,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/main/Exceptions.cs

--- a/docs/api/AutoCheck.Core.Exceptions.VariableNotFoundException.yml
+++ b/docs/api/AutoCheck.Core.Exceptions.VariableNotFoundException.yml
@@ -17,7 +17,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: VariableNotFoundException
     path: ../core/main/Exceptions.cs
@@ -55,7 +55,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/main/Exceptions.cs
@@ -85,7 +85,7 @@ items:
   source:
     remote:
       path: core/main/Exceptions.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/main/Exceptions.cs

--- a/docs/api/AutoCheck.Core.Output.Log.yml
+++ b/docs/api/AutoCheck.Core.Output.Log.yml
@@ -18,7 +18,7 @@ items:
   source:
     remote:
       path: core/main/Output.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Log
     path: ../core/main/Output.cs
@@ -55,7 +55,7 @@ items:
   source:
     remote:
       path: core/main/Output.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/main/Output.cs
@@ -85,7 +85,7 @@ items:
   source:
     remote:
       path: core/main/Output.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ToText
     path: ../core/main/Output.cs
@@ -120,7 +120,7 @@ items:
   source:
     remote:
       path: core/main/Output.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ToJson
     path: ../core/main/Output.cs

--- a/docs/api/AutoCheck.Core.Output.Style.yml
+++ b/docs/api/AutoCheck.Core.Output.Style.yml
@@ -27,7 +27,7 @@ items:
   source:
     remote:
       path: core/main/Output.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Style
     path: ../core/main/Output.cs
@@ -60,7 +60,7 @@ items:
   source:
     remote:
       path: core/main/Output.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: INFO
     path: ../core/main/Output.cs
@@ -92,7 +92,7 @@ items:
   source:
     remote:
       path: core/main/Output.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: PROMPT
     path: ../core/main/Output.cs
@@ -124,7 +124,7 @@ items:
   source:
     remote:
       path: core/main/Output.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: HEADER
     path: ../core/main/Output.cs
@@ -156,7 +156,7 @@ items:
   source:
     remote:
       path: core/main/Output.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CRITICAL
     path: ../core/main/Output.cs
@@ -188,7 +188,7 @@ items:
   source:
     remote:
       path: core/main/Output.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: DETAILS
     path: ../core/main/Output.cs
@@ -220,7 +220,7 @@ items:
   source:
     remote:
       path: core/main/Output.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: QUESTION
     path: ../core/main/Output.cs
@@ -252,7 +252,7 @@ items:
   source:
     remote:
       path: core/main/Output.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: SCORE
     path: ../core/main/Output.cs
@@ -284,7 +284,7 @@ items:
   source:
     remote:
       path: core/main/Output.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: SUCCESS
     path: ../core/main/Output.cs
@@ -316,7 +316,7 @@ items:
   source:
     remote:
       path: core/main/Output.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ERROR
     path: ../core/main/Output.cs
@@ -348,7 +348,7 @@ items:
   source:
     remote:
       path: core/main/Output.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: DEFAULT
     path: ../core/main/Output.cs
@@ -380,7 +380,7 @@ items:
   source:
     remote:
       path: core/main/Output.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ECHO
     path: ../core/main/Output.cs
@@ -412,7 +412,7 @@ items:
   source:
     remote:
       path: core/main/Output.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: WARNING
     path: ../core/main/Output.cs

--- a/docs/api/AutoCheck.Core.Output.Type.yml
+++ b/docs/api/AutoCheck.Core.Output.Type.yml
@@ -19,7 +19,7 @@ items:
   source:
     remote:
       path: core/main/Output.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Type
     path: ../core/main/Output.cs
@@ -52,7 +52,7 @@ items:
   source:
     remote:
       path: core/main/Output.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: HEADER
     path: ../core/main/Output.cs
@@ -84,7 +84,7 @@ items:
   source:
     remote:
       path: core/main/Output.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: SETUP
     path: ../core/main/Output.cs
@@ -116,7 +116,7 @@ items:
   source:
     remote:
       path: core/main/Output.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: SCRIPT
     path: ../core/main/Output.cs
@@ -148,7 +148,7 @@ items:
   source:
     remote:
       path: core/main/Output.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: TEARDOWN
     path: ../core/main/Output.cs

--- a/docs/api/AutoCheck.Core.Output.yml
+++ b/docs/api/AutoCheck.Core.Output.yml
@@ -30,7 +30,7 @@ items:
   source:
     remote:
       path: core/main/Output.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Output
     path: ../core/main/Output.cs
@@ -70,7 +70,7 @@ items:
   source:
     remote:
       path: core/main/Output.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: SingleIndent
     path: ../core/main/Output.cs
@@ -103,7 +103,7 @@ items:
   source:
     remote:
       path: core/main/Output.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CurrentIndent
     path: ../core/main/Output.cs
@@ -138,7 +138,7 @@ items:
   source:
     remote:
       path: core/main/Output.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/main/Output.cs
@@ -174,7 +174,7 @@ items:
   source:
     remote:
       path: core/main/Output.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Write
     path: ../core/main/Output.cs
@@ -213,7 +213,7 @@ items:
   source:
     remote:
       path: core/main/Output.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: WriteLine
     path: ../core/main/Output.cs
@@ -252,7 +252,7 @@ items:
   source:
     remote:
       path: core/main/Output.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: WriteResponse
     path: ../core/main/Output.cs
@@ -295,7 +295,7 @@ items:
   source:
     remote:
       path: core/main/Output.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: WriteResponse
     path: ../core/main/Output.cs
@@ -334,7 +334,7 @@ items:
   source:
     remote:
       path: core/main/Output.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Indent
     path: ../core/main/Output.cs
@@ -366,7 +366,7 @@ items:
   source:
     remote:
       path: core/main/Output.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: UnIndent
     path: ../core/main/Output.cs
@@ -398,7 +398,7 @@ items:
   source:
     remote:
       path: core/main/Output.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ResetIndent
     path: ../core/main/Output.cs
@@ -430,7 +430,7 @@ items:
   source:
     remote:
       path: core/main/Output.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: BreakLine
     path: ../core/main/Output.cs
@@ -466,7 +466,7 @@ items:
   source:
     remote:
       path: core/main/Output.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CloseLog
     path: ../core/main/Output.cs
@@ -501,7 +501,7 @@ items:
   source:
     remote:
       path: core/main/Output.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GetLog
     path: ../core/main/Output.cs
@@ -535,7 +535,7 @@ items:
   source:
     remote:
       path: core/main/Output.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ToString
     path: ../core/main/Output.cs
@@ -570,7 +570,7 @@ items:
   source:
     remote:
       path: core/main/Output.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: SendToTerminal
     path: ../core/main/Output.cs

--- a/docs/api/AutoCheck.Core.Script.ExecutionModeType.yml
+++ b/docs/api/AutoCheck.Core.Script.ExecutionModeType.yml
@@ -17,7 +17,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ExecutionModeType
     path: ../core/main/Script.cs
@@ -50,7 +50,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: SINGLE
     path: ../core/main/Script.cs
@@ -82,7 +82,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: BATCH
     path: ../core/main/Script.cs

--- a/docs/api/AutoCheck.Core.Script.LogGeneratedEventArgs.yml
+++ b/docs/api/AutoCheck.Core.Script.LogGeneratedEventArgs.yml
@@ -18,7 +18,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: LogGeneratedEventArgs
     path: ../core/main/Script.cs
@@ -55,7 +55,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Type
     path: ../core/main/Script.cs
@@ -90,7 +90,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ExecutionMode
     path: ../core/main/Script.cs
@@ -125,7 +125,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Log
     path: ../core/main/Script.cs

--- a/docs/api/AutoCheck.Core.Script.yml
+++ b/docs/api/AutoCheck.Core.Script.yml
@@ -54,7 +54,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Script
     path: ../core/main/Script.cs
@@ -91,7 +91,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ScriptName
     path: ../core/main/Script.cs
@@ -128,7 +128,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ScriptVersion
     path: ../core/main/Script.cs
@@ -165,7 +165,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ScriptCaption
     path: ../core/main/Script.cs
@@ -202,7 +202,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: SingleCaption
     path: ../core/main/Script.cs
@@ -239,7 +239,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: BatchCaption
     path: ../core/main/Script.cs
@@ -276,7 +276,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: AppFolderPath
     path: ../core/main/Script.cs
@@ -313,7 +313,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: AppFolderName
     path: ../core/main/Script.cs
@@ -350,7 +350,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ExecutionFolderPath
     path: ../core/main/Script.cs
@@ -387,7 +387,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ExecutionFolderName
     path: ../core/main/Script.cs
@@ -424,7 +424,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ScriptFolderPath
     path: ../core/main/Script.cs
@@ -461,7 +461,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ScriptFolderName
     path: ../core/main/Script.cs
@@ -498,7 +498,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ScriptFilePath
     path: ../core/main/Script.cs
@@ -535,7 +535,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ScriptFileName
     path: ../core/main/Script.cs
@@ -572,7 +572,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CurrentFolderPath
     path: ../core/main/Script.cs
@@ -609,7 +609,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CurrentFolderName
     path: ../core/main/Script.cs
@@ -646,7 +646,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CurrentFilePath
     path: ../core/main/Script.cs
@@ -683,7 +683,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CurrentFileName
     path: ../core/main/Script.cs
@@ -720,7 +720,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: LogFolderPath
     path: ../core/main/Script.cs
@@ -757,7 +757,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: LogFolderName
     path: ../core/main/Script.cs
@@ -794,7 +794,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: LogFilePath
     path: ../core/main/Script.cs
@@ -831,7 +831,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: LogFileName
     path: ../core/main/Script.cs
@@ -868,7 +868,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CurrentTarget
     path: ../core/main/Script.cs
@@ -905,7 +905,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CurrentOS
     path: ../core/main/Script.cs
@@ -942,7 +942,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CurrentHost
     path: ../core/main/Script.cs
@@ -979,7 +979,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CurrentUser
     path: ../core/main/Script.cs
@@ -1016,7 +1016,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CurrentPassword
     path: ../core/main/Script.cs
@@ -1053,7 +1053,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CurrentPort
     path: ../core/main/Script.cs
@@ -1090,7 +1090,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CurrentQuestion
     path: ../core/main/Script.cs
@@ -1127,7 +1127,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Result
     path: ../core/main/Script.cs
@@ -1165,7 +1165,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Now
     path: ../core/main/Script.cs
@@ -1202,7 +1202,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CurrentScore
     path: ../core/main/Script.cs
@@ -1239,7 +1239,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: MaxScore
     path: ../core/main/Script.cs
@@ -1276,7 +1276,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: TotalScore
     path: ../core/main/Script.cs
@@ -1313,7 +1313,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Concurrent
     path: ../core/main/Script.cs
@@ -1350,7 +1350,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Output
     path: ../core/main/Script.cs
@@ -1387,7 +1387,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: LogFiles
     path: ../core/main/Script.cs
@@ -1424,7 +1424,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/main/Script.cs
@@ -1457,7 +1457,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/main/Script.cs
@@ -1495,7 +1495,7 @@ items:
   source:
     remote:
       path: core/main/Script.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: .ctor
     path: ../core/main/Script.cs

--- a/docs/api/AutoCheck.Core.Utils.OS.yml
+++ b/docs/api/AutoCheck.Core.Utils.OS.yml
@@ -18,7 +18,7 @@ items:
   source:
     remote:
       path: core/main/Utils.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: OS
     path: ../core/main/Utils.cs
@@ -51,7 +51,7 @@ items:
   source:
     remote:
       path: core/main/Utils.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: GNU
     path: ../core/main/Utils.cs
@@ -83,7 +83,7 @@ items:
   source:
     remote:
       path: core/main/Utils.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: MAC
     path: ../core/main/Utils.cs
@@ -115,7 +115,7 @@ items:
   source:
     remote:
       path: core/main/Utils.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: WIN
     path: ../core/main/Utils.cs

--- a/docs/api/AutoCheck.Core.Utils.yml
+++ b/docs/api/AutoCheck.Core.Utils.yml
@@ -27,7 +27,7 @@ items:
   source:
     remote:
       path: core/main/Utils.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: Utils
     path: ../core/main/Utils.cs
@@ -63,7 +63,7 @@ items:
   source:
     remote:
       path: core/main/Utils.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: AppFolder
     path: ../core/main/Utils.cs
@@ -103,7 +103,7 @@ items:
   source:
     remote:
       path: core/main/Utils.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ExecutionFolder
     path: ../core/main/Utils.cs
@@ -143,7 +143,7 @@ items:
   source:
     remote:
       path: core/main/Utils.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ConfigFolder
     path: ../core/main/Utils.cs
@@ -183,7 +183,7 @@ items:
   source:
     remote:
       path: core/main/Utils.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: TempFolder
     path: ../core/main/Utils.cs
@@ -223,7 +223,7 @@ items:
   source:
     remote:
       path: core/main/Utils.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: CurrentOS
     path: ../core/main/Utils.cs
@@ -264,7 +264,7 @@ items:
   source:
     remote:
       path: core/main/Utils.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ToCamelCase
     path: ../core/main/Utils.cs
@@ -309,7 +309,7 @@ items:
   source:
     remote:
       path: core/main/Utils.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: RemoveDiacritics
     path: ../core/main/Utils.cs
@@ -353,7 +353,7 @@ items:
   source:
     remote:
       path: core/main/Utils.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: RunWithRetry
     path: ../core/main/Utils.cs
@@ -404,7 +404,7 @@ items:
   source:
     remote:
       path: core/main/Utils.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: RunWithRetry
     path: ../core/main/Utils.cs
@@ -457,7 +457,7 @@ items:
   source:
     remote:
       path: core/main/Utils.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: PathToCurrentOS
     path: ../core/main/Utils.cs
@@ -497,7 +497,7 @@ items:
   source:
     remote:
       path: core/main/Utils.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: PathToRemoteOS
     path: ../core/main/Utils.cs
@@ -539,7 +539,7 @@ items:
   source:
     remote:
       path: core/main/Utils.cs
-      branch: master
+      branch: v2.12.2
       repo: https://github.com/FherStk/AutoCheck.git
     id: ConfigFile
     path: ../core/main/Utils.cs

--- a/docs/html/api/AutoCheck.Core.Connectors.Atom.html
+++ b/docs/html/api/AutoCheck.Core.Connectors.Atom.html
@@ -336,7 +336,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Atom__ctor_AutoCheck_Core_Utils_OS_System_String_System_String_System_String_System_Int32_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Atom.%23ctor(AutoCheck.Core.Utils.OS%2CSystem.String%2CSystem.String%2CSystem.String%2CSystem.Int32%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Atom.cs/#L42">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Atom.cs/#L42">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Atom__ctor_" data-uid="AutoCheck.Core.Connectors.Atom.#ctor*"></a>
   <h4 id="AutoCheck_Core_Connectors_Atom__ctor_AutoCheck_Core_Utils_OS_System_String_System_String_System_String_System_Int32_System_String_" data-uid="AutoCheck.Core.Connectors.Atom.#ctor(AutoCheck.Core.Utils.OS,System.String,System.String,System.String,System.Int32,System.String)">Atom(Utils.OS, String, String, String, Int32, String)</h4>
@@ -393,7 +393,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Atom__ctor_AutoCheck_Core_Utils_OS_System_String_System_String_System_String_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Atom.%23ctor(AutoCheck.Core.Utils.OS%2CSystem.String%2CSystem.String%2CSystem.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Atom.cs/#L53">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Atom.cs/#L53">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Atom__ctor_" data-uid="AutoCheck.Core.Connectors.Atom.#ctor*"></a>
   <h4 id="AutoCheck_Core_Connectors_Atom__ctor_AutoCheck_Core_Utils_OS_System_String_System_String_System_String_System_String_" data-uid="AutoCheck.Core.Connectors.Atom.#ctor(AutoCheck.Core.Utils.OS,System.String,System.String,System.String,System.String)">Atom(Utils.OS, String, String, String, String)</h4>
@@ -445,7 +445,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Atom__ctor_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Atom.%23ctor(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Atom.cs/#L30">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Atom.cs/#L30">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Atom__ctor_" data-uid="AutoCheck.Core.Connectors.Atom.#ctor*"></a>
   <h4 id="AutoCheck_Core_Connectors_Atom__ctor_System_String_" data-uid="AutoCheck.Core.Connectors.Atom.#ctor(System.String)">Atom(String)</h4>
@@ -481,7 +481,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Atom_Dispose.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Atom.Dispose%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Atom.cs/#L60">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Atom.cs/#L60">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Atom_Dispose_" data-uid="AutoCheck.Core.Connectors.Atom.Dispose*"></a>
   <h4 id="AutoCheck_Core_Connectors_Atom_Dispose" data-uid="AutoCheck.Core.Connectors.Atom.Dispose">Dispose()</h4>
@@ -499,7 +499,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Atom_ValidateAtomAgainstW3C.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Atom.ValidateAtomAgainstW3C%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Atom.cs/#L67">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Atom.cs/#L67">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Atom_ValidateAtomAgainstW3C_" data-uid="AutoCheck.Core.Connectors.Atom.ValidateAtomAgainstW3C*"></a>
   <h4 id="AutoCheck_Core_Connectors_Atom_ValidateAtomAgainstW3C" data-uid="AutoCheck.Core.Connectors.Atom.ValidateAtomAgainstW3C">ValidateAtomAgainstW3C()</h4>
@@ -526,7 +526,7 @@ Throws an exception if the document is invalid.</p>
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Atom.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Atom%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Atom.cs/#L25" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Atom.cs/#L25" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.Connectors.Base.html
+++ b/docs/html/api/AutoCheck.Core.Connectors.Base.html
@@ -308,7 +308,7 @@ This class is an abstraction layer between a checker (to a lesser extent, a scri
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Base_Dispose.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Base.Dispose%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Base.cs/#L46">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Base.cs/#L46">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Base_Dispose_" data-uid="AutoCheck.Core.Connectors.Base.Dispose*"></a>
   <h4 id="AutoCheck_Core_Connectors_Base_Dispose" data-uid="AutoCheck.Core.Connectors.Base.Dispose">Dispose()</h4>
@@ -324,7 +324,7 @@ This class is an abstraction layer between a checker (to a lesser extent, a scri
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Base_ProcessRemoteFile_AutoCheck_Core_Utils_OS_System_String_System_String_System_String_System_Int32_System_String_Action_System_String__.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Base.ProcessRemoteFile(AutoCheck.Core.Utils.OS%2CSystem.String%2CSystem.String%2CSystem.String%2CSystem.Int32%2CSystem.String%2CAction%7BSystem.String%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Base.cs/#L52">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Base.cs/#L52">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Base_ProcessRemoteFile_" data-uid="AutoCheck.Core.Connectors.Base.ProcessRemoteFile*"></a>
   <h4 id="AutoCheck_Core_Connectors_Base_ProcessRemoteFile_AutoCheck_Core_Utils_OS_System_String_System_String_System_String_System_Int32_System_String_Action_System_String__" data-uid="AutoCheck.Core.Connectors.Base.ProcessRemoteFile(AutoCheck.Core.Utils.OS,System.String,System.String,System.String,System.Int32,System.String,Action{System.String})">ProcessRemoteFile(Utils.OS, String, String, String, Int32, String, Action&lt;String&gt;)</h4>
@@ -398,7 +398,7 @@ This class is an abstraction layer between a checker (to a lesser extent, a scri
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Base.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Base%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Base.cs/#L42" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Base.cs/#L42" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.Connectors.Css.html
+++ b/docs/html/api/AutoCheck.Core.Connectors.Css.html
@@ -304,7 +304,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Css__ctor_AutoCheck_Core_Utils_OS_System_String_System_String_System_String_System_Int32_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Css.%23ctor(AutoCheck.Core.Utils.OS%2CSystem.String%2CSystem.String%2CSystem.String%2CSystem.Int32%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Css.cs/#L67">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Css.cs/#L67">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Css__ctor_" data-uid="AutoCheck.Core.Connectors.Css.#ctor*"></a>
   <h4 id="AutoCheck_Core_Connectors_Css__ctor_AutoCheck_Core_Utils_OS_System_String_System_String_System_String_System_Int32_System_String_" data-uid="AutoCheck.Core.Connectors.Css.#ctor(AutoCheck.Core.Utils.OS,System.String,System.String,System.String,System.Int32,System.String)">Css(Utils.OS, String, String, String, Int32, String)</h4>
@@ -361,7 +361,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Css__ctor_AutoCheck_Core_Utils_OS_System_String_System_String_System_String_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Css.%23ctor(AutoCheck.Core.Utils.OS%2CSystem.String%2CSystem.String%2CSystem.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Css.cs/#L81">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Css.cs/#L81">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Css__ctor_" data-uid="AutoCheck.Core.Connectors.Css.#ctor*"></a>
   <h4 id="AutoCheck_Core_Connectors_Css__ctor_AutoCheck_Core_Utils_OS_System_String_System_String_System_String_System_String_" data-uid="AutoCheck.Core.Connectors.Css.#ctor(AutoCheck.Core.Utils.OS,System.String,System.String,System.String,System.String)">Css(Utils.OS, String, String, String, String)</h4>
@@ -413,7 +413,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Css__ctor_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Css.%23ctor(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Css.cs/#L54">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Css.cs/#L54">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Css__ctor_" data-uid="AutoCheck.Core.Connectors.Css.#ctor*"></a>
   <h4 id="AutoCheck_Core_Connectors_Css__ctor_System_String_" data-uid="AutoCheck.Core.Connectors.Css.#ctor(System.String)">Css(String)</h4>
@@ -449,7 +449,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Css_CssDoc.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Css.CssDoc%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Css.cs/#L42">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Css.cs/#L42">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Css_CssDoc_" data-uid="AutoCheck.Core.Connectors.Css.CssDoc*"></a>
   <h4 id="AutoCheck_Core_Connectors_Css_CssDoc" data-uid="AutoCheck.Core.Connectors.Css.CssDoc">CssDoc</h4>
@@ -480,7 +480,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Css_Raw.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Css.Raw%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Css.cs/#L48">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Css.cs/#L48">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Css_Raw_" data-uid="AutoCheck.Core.Connectors.Css.Raw*"></a>
   <h4 id="AutoCheck_Core_Connectors_Css_Raw" data-uid="AutoCheck.Core.Connectors.Css.Raw">Raw</h4>
@@ -513,7 +513,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Css_Dispose.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Css.Dispose%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Css.cs/#L96">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Css.cs/#L96">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Css_Dispose_" data-uid="AutoCheck.Core.Connectors.Css.Dispose*"></a>
   <h4 id="AutoCheck_Core_Connectors_Css_Dispose" data-uid="AutoCheck.Core.Connectors.Css.Dispose">Dispose()</h4>
@@ -531,7 +531,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Css_PropertyApplied_AutoCheck_Core_Connectors_Html_Dictionary_System_String_System_String__.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Css.PropertyApplied(AutoCheck.Core.Connectors.Html%2CDictionary%7BSystem.String%2CSystem.String%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Css.cs/#L248">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Css.cs/#L248">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Css_PropertyApplied_" data-uid="AutoCheck.Core.Connectors.Css.PropertyApplied*"></a>
   <h4 id="AutoCheck_Core_Connectors_Css_PropertyApplied_AutoCheck_Core_Connectors_Html_Dictionary_System_String_System_String__" data-uid="AutoCheck.Core.Connectors.Css.PropertyApplied(AutoCheck.Core.Connectors.Html,Dictionary{System.String,System.String})">PropertyApplied(Html, Dictionary&lt;String, String&gt;)</h4>
@@ -587,7 +587,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Css_PropertyApplied_AutoCheck_Core_Connectors_Html_System_String_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Css.PropertyApplied(AutoCheck.Core.Connectors.Html%2CSystem.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Css.cs/#L228">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Css.cs/#L228">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Css_PropertyApplied_" data-uid="AutoCheck.Core.Connectors.Css.PropertyApplied*"></a>
   <h4 id="AutoCheck_Core_Connectors_Css_PropertyApplied_AutoCheck_Core_Connectors_Html_System_String_System_String_" data-uid="AutoCheck.Core.Connectors.Css.PropertyApplied(AutoCheck.Core.Connectors.Html,System.String,System.String)">PropertyApplied(Html, String, String)</h4>
@@ -644,7 +644,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Css_PropertyApplied_AutoCheck_Core_Connectors_Html_System_String___.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Css.PropertyApplied(AutoCheck.Core.Connectors.Html%2CSystem.String%5B%5D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Css.cs/#L238">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Css.cs/#L238">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Css_PropertyApplied_" data-uid="AutoCheck.Core.Connectors.Css.PropertyApplied*"></a>
   <h4 id="AutoCheck_Core_Connectors_Css_PropertyApplied_AutoCheck_Core_Connectors_Html_System_String___" data-uid="AutoCheck.Core.Connectors.Css.PropertyApplied(AutoCheck.Core.Connectors.Html,System.String[])">PropertyApplied(Html, String[])</h4>
@@ -700,7 +700,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Css_PropertyApplied_HtmlDocument_Dictionary_System_String_System_String__.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Css.PropertyApplied(HtmlDocument%2CDictionary%7BSystem.String%2CSystem.String%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Css.cs/#L210">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Css.cs/#L210">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Css_PropertyApplied_" data-uid="AutoCheck.Core.Connectors.Css.PropertyApplied*"></a>
   <h4 id="AutoCheck_Core_Connectors_Css_PropertyApplied_HtmlDocument_Dictionary_System_String_System_String__" data-uid="AutoCheck.Core.Connectors.Css.PropertyApplied(HtmlDocument,Dictionary{System.String,System.String})">PropertyApplied(HtmlDocument, Dictionary&lt;String, String&gt;)</h4>
@@ -756,7 +756,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Css_PropertyApplied_HtmlDocument_System_String_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Css.PropertyApplied(HtmlDocument%2CSystem.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Css.cs/#L175">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Css.cs/#L175">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Css_PropertyApplied_" data-uid="AutoCheck.Core.Connectors.Css.PropertyApplied*"></a>
   <h4 id="AutoCheck_Core_Connectors_Css_PropertyApplied_HtmlDocument_System_String_System_String_" data-uid="AutoCheck.Core.Connectors.Css.PropertyApplied(HtmlDocument,System.String,System.String)">PropertyApplied(HtmlDocument, String, String)</h4>
@@ -813,7 +813,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Css_PropertyApplied_HtmlDocument_System_String___.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Css.PropertyApplied(HtmlDocument%2CSystem.String%5B%5D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Css.cs/#L200">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Css.cs/#L200">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Css_PropertyApplied_" data-uid="AutoCheck.Core.Connectors.Css.PropertyApplied*"></a>
   <h4 id="AutoCheck_Core_Connectors_Css_PropertyApplied_HtmlDocument_System_String___" data-uid="AutoCheck.Core.Connectors.Css.PropertyApplied(HtmlDocument,System.String[])">PropertyApplied(HtmlDocument, String[])</h4>
@@ -869,7 +869,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Css_PropertyExists_Dictionary_System_String_System_String__.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Css.PropertyExists(Dictionary%7BSystem.String%2CSystem.String%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Css.cs/#L157">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Css.cs/#L157">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Css_PropertyExists_" data-uid="AutoCheck.Core.Connectors.Css.PropertyExists*"></a>
   <h4 id="AutoCheck_Core_Connectors_Css_PropertyExists_Dictionary_System_String_System_String__" data-uid="AutoCheck.Core.Connectors.Css.PropertyExists(Dictionary{System.String,System.String})">PropertyExists(Dictionary&lt;String, String&gt;)</h4>
@@ -919,7 +919,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Css_PropertyExists_System_String_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Css.PropertyExists(System.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Css.cs/#L134">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Css.cs/#L134">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Css_PropertyExists_" data-uid="AutoCheck.Core.Connectors.Css.PropertyExists*"></a>
   <h4 id="AutoCheck_Core_Connectors_Css_PropertyExists_System_String_System_String_" data-uid="AutoCheck.Core.Connectors.Css.PropertyExists(System.String,System.String)">PropertyExists(String, String)</h4>
@@ -975,7 +975,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Css_PropertyExists_System_String___.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Css.PropertyExists(System.String%5B%5D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Css.cs/#L148">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Css.cs/#L148">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Css_PropertyExists_" data-uid="AutoCheck.Core.Connectors.Css.PropertyExists*"></a>
   <h4 id="AutoCheck_Core_Connectors_Css_PropertyExists_System_String___" data-uid="AutoCheck.Core.Connectors.Css.PropertyExists(System.String[])">PropertyExists(String[])</h4>
@@ -1025,7 +1025,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Css_ValidateCss3AgainstW3C.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Css.ValidateCss3AgainstW3C%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Css.cs/#L103">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Css.cs/#L103">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Css_ValidateCss3AgainstW3C_" data-uid="AutoCheck.Core.Connectors.Css.ValidateCss3AgainstW3C*"></a>
   <h4 id="AutoCheck_Core_Connectors_Css_ValidateCss3AgainstW3C" data-uid="AutoCheck.Core.Connectors.Css.ValidateCss3AgainstW3C">ValidateCss3AgainstW3C()</h4>
@@ -1052,7 +1052,7 @@ Throws an exception if the document is invalid.</p>
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Css.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Css%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Css.cs/#L37" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Css.cs/#L37" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.Connectors.Csv.html
+++ b/docs/html/api/AutoCheck.Core.Connectors.Csv.html
@@ -304,7 +304,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Csv__ctor_AutoCheck_Core_Utils_OS_System_String_System_String_System_String_System_Int32_System_String_System_Char_System_Char_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Csv.%23ctor(AutoCheck.Core.Utils.OS%2CSystem.String%2CSystem.String%2CSystem.String%2CSystem.Int32%2CSystem.String%2CSystem.Char%2CSystem.Char)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Csv.cs/#L180">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Csv.cs/#L180">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Csv__ctor_" data-uid="AutoCheck.Core.Connectors.Csv.#ctor*"></a>
   <h4 id="AutoCheck_Core_Connectors_Csv__ctor_AutoCheck_Core_Utils_OS_System_String_System_String_System_String_System_Int32_System_String_System_Char_System_Char_" data-uid="AutoCheck.Core.Connectors.Csv.#ctor(AutoCheck.Core.Utils.OS,System.String,System.String,System.String,System.Int32,System.String,System.Char,System.Char)">Csv(Utils.OS, String, String, String, Int32, String, Char, Char)</h4>
@@ -371,7 +371,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Csv__ctor_AutoCheck_Core_Utils_OS_System_String_System_String_System_String_System_String_System_Char_System_Char_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Csv.%23ctor(AutoCheck.Core.Utils.OS%2CSystem.String%2CSystem.String%2CSystem.String%2CSystem.String%2CSystem.Char%2CSystem.Char)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Csv.cs/#L194">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Csv.cs/#L194">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Csv__ctor_" data-uid="AutoCheck.Core.Connectors.Csv.#ctor*"></a>
   <h4 id="AutoCheck_Core_Connectors_Csv__ctor_AutoCheck_Core_Utils_OS_System_String_System_String_System_String_System_String_System_Char_System_Char_" data-uid="AutoCheck.Core.Connectors.Csv.#ctor(AutoCheck.Core.Utils.OS,System.String,System.String,System.String,System.String,System.Char,System.Char)">Csv(Utils.OS, String, String, String, String, Char, Char)</h4>
@@ -433,7 +433,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Csv__ctor_System_String_System_Char_System_Char_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Csv.%23ctor(System.String%2CSystem.Char%2CSystem.Char)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Csv.cs/#L167">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Csv.cs/#L167">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Csv__ctor_" data-uid="AutoCheck.Core.Connectors.Csv.#ctor*"></a>
   <h4 id="AutoCheck_Core_Connectors_Csv__ctor_System_String_System_Char_System_Char_" data-uid="AutoCheck.Core.Connectors.Csv.#ctor(System.String,System.Char,System.Char)">Csv(String, Char, Char)</h4>
@@ -481,7 +481,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Csv_CsvDoc.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Csv.CsvDoc%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Csv.cs/#L159">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Csv.cs/#L159">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Csv_CsvDoc_" data-uid="AutoCheck.Core.Connectors.Csv.CsvDoc*"></a>
   <h4 id="AutoCheck_Core_Connectors_Csv_CsvDoc" data-uid="AutoCheck.Core.Connectors.Csv.CsvDoc">CsvDoc</h4>
@@ -514,7 +514,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Csv_Dispose.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Csv.Dispose%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Csv.cs/#L208">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Csv.cs/#L208">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Csv_Dispose_" data-uid="AutoCheck.Core.Connectors.Csv.Dispose*"></a>
   <h4 id="AutoCheck_Core_Connectors_Csv_Dispose" data-uid="AutoCheck.Core.Connectors.Csv.Dispose">Dispose()</h4>
@@ -542,7 +542,7 @@
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Csv.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Csv%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Csv.cs/#L154" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Csv.cs/#L154" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.Connectors.CsvDocument.html
+++ b/docs/html/api/AutoCheck.Core.Connectors.CsvDocument.html
@@ -297,7 +297,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_CsvDocument__ctor_System_String_System_Char_System_Char_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.CsvDocument.%23ctor(System.String%2CSystem.Char%2CSystem.Char)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Csv.cs/#L70">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Csv.cs/#L70">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_CsvDocument__ctor_" data-uid="AutoCheck.Core.Connectors.CsvDocument.#ctor*"></a>
   <h4 id="AutoCheck_Core_Connectors_CsvDocument__ctor_System_String_System_Char_System_Char_" data-uid="AutoCheck.Core.Connectors.CsvDocument.#ctor(System.String,System.Char,System.Char)">CsvDocument(String, Char, Char)</h4>
@@ -345,7 +345,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_CsvDocument_Content.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.CsvDocument.Content%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Csv.cs/#L41">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Csv.cs/#L41">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_CsvDocument_Content_" data-uid="AutoCheck.Core.Connectors.CsvDocument.Content*"></a>
   <h4 id="AutoCheck_Core_Connectors_CsvDocument_Content" data-uid="AutoCheck.Core.Connectors.CsvDocument.Content">Content</h4>
@@ -376,7 +376,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_CsvDocument_Count.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.CsvDocument.Count%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Csv.cs/#L58">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Csv.cs/#L58">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_CsvDocument_Count_" data-uid="AutoCheck.Core.Connectors.CsvDocument.Count*"></a>
   <h4 id="AutoCheck_Core_Connectors_CsvDocument_Count" data-uid="AutoCheck.Core.Connectors.CsvDocument.Count">Count</h4>
@@ -407,7 +407,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_CsvDocument_Headers.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.CsvDocument.Headers%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Csv.cs/#L47">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Csv.cs/#L47">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_CsvDocument_Headers_" data-uid="AutoCheck.Core.Connectors.CsvDocument.Headers*"></a>
   <h4 id="AutoCheck_Core_Connectors_CsvDocument_Headers" data-uid="AutoCheck.Core.Connectors.CsvDocument.Headers">Headers</h4>
@@ -440,7 +440,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_CsvDocument_GetLine_System_Int32_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.CsvDocument.GetLine(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Csv.cs/#L113">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Csv.cs/#L113">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_CsvDocument_GetLine_" data-uid="AutoCheck.Core.Connectors.CsvDocument.GetLine*"></a>
   <h4 id="AutoCheck_Core_Connectors_CsvDocument_GetLine_System_Int32_" data-uid="AutoCheck.Core.Connectors.CsvDocument.GetLine(System.Int32)">GetLine(Int32)</h4>
@@ -489,7 +489,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_CsvDocument_Validate.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.CsvDocument.Validate%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Csv.cs/#L101">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Csv.cs/#L101">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_CsvDocument_Validate_" data-uid="AutoCheck.Core.Connectors.CsvDocument.Validate*"></a>
   <h4 id="AutoCheck_Core_Connectors_CsvDocument_Validate" data-uid="AutoCheck.Core.Connectors.CsvDocument.Validate">Validate()</h4>
@@ -515,7 +515,7 @@
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_CsvDocument.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.CsvDocument%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Csv.cs/#L31" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Csv.cs/#L31" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.Connectors.GDrive.html
+++ b/docs/html/api/AutoCheck.Core.Connectors.GDrive.html
@@ -304,7 +304,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_GDrive__ctor_AutoCheck_Core_Utils_OS_System_String_System_String_System_String_System_Int32_System_String_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.GDrive.%23ctor(AutoCheck.Core.Utils.OS%2CSystem.String%2CSystem.String%2CSystem.String%2CSystem.Int32%2CSystem.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/GDrive.cs/#L90">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/GDrive.cs/#L90">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_GDrive__ctor_" data-uid="AutoCheck.Core.Connectors.GDrive.#ctor*"></a>
   <h4 id="AutoCheck_Core_Connectors_GDrive__ctor_AutoCheck_Core_Utils_OS_System_String_System_String_System_String_System_Int32_System_String_System_String_" data-uid="AutoCheck.Core.Connectors.GDrive.#ctor(AutoCheck.Core.Utils.OS,System.String,System.String,System.String,System.Int32,System.String,System.String)">GDrive(Utils.OS, String, String, String, Int32, String, String)</h4>
@@ -366,7 +366,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_GDrive__ctor_AutoCheck_Core_Utils_OS_System_String_System_String_System_String_System_String_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.GDrive.%23ctor(AutoCheck.Core.Utils.OS%2CSystem.String%2CSystem.String%2CSystem.String%2CSystem.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/GDrive.cs/#L77">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/GDrive.cs/#L77">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_GDrive__ctor_" data-uid="AutoCheck.Core.Connectors.GDrive.#ctor*"></a>
   <h4 id="AutoCheck_Core_Connectors_GDrive__ctor_AutoCheck_Core_Utils_OS_System_String_System_String_System_String_System_String_System_String_" data-uid="AutoCheck.Core.Connectors.GDrive.#ctor(AutoCheck.Core.Utils.OS,System.String,System.String,System.String,System.String,System.String)">GDrive(Utils.OS, String, String, String, String, String)</h4>
@@ -423,7 +423,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_GDrive__ctor_System_String_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.GDrive.%23ctor(System.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/GDrive.cs/#L55">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/GDrive.cs/#L55">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_GDrive__ctor_" data-uid="AutoCheck.Core.Connectors.GDrive.#ctor*"></a>
   <h4 id="AutoCheck_Core_Connectors_GDrive__ctor_System_String_System_String_" data-uid="AutoCheck.Core.Connectors.GDrive.#ctor(System.String,System.String)">GDrive(String, String)</h4>
@@ -465,7 +465,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_GDrive_Drive.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.GDrive.Drive%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/GDrive.cs/#L46">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/GDrive.cs/#L46">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_GDrive_Drive_" data-uid="AutoCheck.Core.Connectors.GDrive.Drive*"></a>
   <h4 id="AutoCheck_Core_Connectors_GDrive_Drive" data-uid="AutoCheck.Core.Connectors.GDrive.Drive">Drive</h4>
@@ -497,7 +497,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_GDrive_CopyFile_Google_Apis_Drive_v3_Data_File_System_String_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.GDrive.CopyFile(Google.Apis.Drive.v3.Data.File%2CSystem.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/GDrive.cs/#L461">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/GDrive.cs/#L461">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_GDrive_CopyFile_" data-uid="AutoCheck.Core.Connectors.GDrive.CopyFile*"></a>
   <h4 id="AutoCheck_Core_Connectors_GDrive_CopyFile_Google_Apis_Drive_v3_Data_File_System_String_System_String_" data-uid="AutoCheck.Core.Connectors.GDrive.CopyFile(Google.Apis.Drive.v3.Data.File,System.String,System.String)">CopyFile(Google.Apis.Drive.v3.Data.File, String, String)</h4>
@@ -543,7 +543,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_GDrive_CopyFile_System_String_System_String_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.GDrive.CopyFile(System.String%2CSystem.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/GDrive.cs/#L471">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/GDrive.cs/#L471">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_GDrive_CopyFile_" data-uid="AutoCheck.Core.Connectors.GDrive.CopyFile*"></a>
   <h4 id="AutoCheck_Core_Connectors_GDrive_CopyFile_System_String_System_String_System_String_" data-uid="AutoCheck.Core.Connectors.GDrive.CopyFile(System.String,System.String,System.String)">CopyFile(String, String, String)</h4>
@@ -589,7 +589,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_GDrive_CopyFile_Uri_System_String_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.GDrive.CopyFile(Uri%2CSystem.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/GDrive.cs/#L450">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/GDrive.cs/#L450">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_GDrive_CopyFile_" data-uid="AutoCheck.Core.Connectors.GDrive.CopyFile*"></a>
   <h4 id="AutoCheck_Core_Connectors_GDrive_CopyFile_Uri_System_String_System_String_" data-uid="AutoCheck.Core.Connectors.GDrive.CopyFile(Uri,System.String,System.String)">CopyFile(Uri, String, String)</h4>
@@ -635,7 +635,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_GDrive_CopyFromFile_System_String_System_String_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.GDrive.CopyFromFile(System.String%2CSystem.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/GDrive.cs/#L512">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/GDrive.cs/#L512">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_GDrive_CopyFromFile_" data-uid="AutoCheck.Core.Connectors.GDrive.CopyFromFile*"></a>
   <h4 id="AutoCheck_Core_Connectors_GDrive_CopyFromFile_System_String_System_String_System_String_" data-uid="AutoCheck.Core.Connectors.GDrive.CopyFromFile(System.String,System.String,System.String)">CopyFromFile(String, String, String)</h4>
@@ -681,7 +681,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_GDrive_CountFiles_System_String_System_Boolean_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.GDrive.CountFiles(System.String%2CSystem.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/GDrive.cs/#L338">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/GDrive.cs/#L338">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_GDrive_CountFiles_" data-uid="AutoCheck.Core.Connectors.GDrive.CountFiles*"></a>
   <h4 id="AutoCheck_Core_Connectors_GDrive_CountFiles_System_String_System_Boolean_" data-uid="AutoCheck.Core.Connectors.GDrive.CountFiles(System.String,System.Boolean)">CountFiles(String, Boolean)</h4>
@@ -737,7 +737,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_GDrive_CountFolders_System_String_System_Boolean_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.GDrive.CountFolders(System.String%2CSystem.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/GDrive.cs/#L188">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/GDrive.cs/#L188">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_GDrive_CountFolders_" data-uid="AutoCheck.Core.Connectors.GDrive.CountFolders*"></a>
   <h4 id="AutoCheck_Core_Connectors_GDrive_CountFolders_System_String_System_Boolean_" data-uid="AutoCheck.Core.Connectors.GDrive.CountFolders(System.String,System.Boolean)">CountFolders(String, Boolean)</h4>
@@ -793,7 +793,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_GDrive_CreateFile_System_String_System_String_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.GDrive.CreateFile(System.String%2CSystem.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/GDrive.cs/#L362">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/GDrive.cs/#L362">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_GDrive_CreateFile_" data-uid="AutoCheck.Core.Connectors.GDrive.CreateFile*"></a>
   <h4 id="AutoCheck_Core_Connectors_GDrive_CreateFile_System_String_System_String_System_String_" data-uid="AutoCheck.Core.Connectors.GDrive.CreateFile(System.String,System.String,System.String)">CreateFile(String, String, String)</h4>
@@ -839,7 +839,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_GDrive_CreateFolder_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.GDrive.CreateFolder(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/GDrive.cs/#L107">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/GDrive.cs/#L107">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_GDrive_CreateFolder_" data-uid="AutoCheck.Core.Connectors.GDrive.CreateFolder*"></a>
   <h4 id="AutoCheck_Core_Connectors_GDrive_CreateFolder_System_String_" data-uid="AutoCheck.Core.Connectors.GDrive.CreateFolder(System.String)">CreateFolder(String)</h4>
@@ -888,7 +888,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_GDrive_CreateFolder_System_String_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.GDrive.CreateFolder(System.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/GDrive.cs/#L118">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/GDrive.cs/#L118">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_GDrive_CreateFolder_" data-uid="AutoCheck.Core.Connectors.GDrive.CreateFolder*"></a>
   <h4 id="AutoCheck_Core_Connectors_GDrive_CreateFolder_System_String_System_String_" data-uid="AutoCheck.Core.Connectors.GDrive.CreateFolder(System.String,System.String)">CreateFolder(String, String)</h4>
@@ -943,7 +943,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_GDrive_DeleteFile_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.GDrive.DeleteFile(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/GDrive.cs/#L426">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/GDrive.cs/#L426">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_GDrive_DeleteFile_" data-uid="AutoCheck.Core.Connectors.GDrive.DeleteFile*"></a>
   <h4 id="AutoCheck_Core_Connectors_GDrive_DeleteFile_System_String_" data-uid="AutoCheck.Core.Connectors.GDrive.DeleteFile(System.String)">DeleteFile(String)</h4>
@@ -977,7 +977,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_GDrive_DeleteFile_System_String_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.GDrive.DeleteFile(System.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/GDrive.cs/#L435">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/GDrive.cs/#L435">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_GDrive_DeleteFile_" data-uid="AutoCheck.Core.Connectors.GDrive.DeleteFile*"></a>
   <h4 id="AutoCheck_Core_Connectors_GDrive_DeleteFile_System_String_System_String_" data-uid="AutoCheck.Core.Connectors.GDrive.DeleteFile(System.String,System.String)">DeleteFile(String, String)</h4>
@@ -1017,7 +1017,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_GDrive_DeleteFolder_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.GDrive.DeleteFolder(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/GDrive.cs/#L209">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/GDrive.cs/#L209">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_GDrive_DeleteFolder_" data-uid="AutoCheck.Core.Connectors.GDrive.DeleteFolder*"></a>
   <h4 id="AutoCheck_Core_Connectors_GDrive_DeleteFolder_System_String_" data-uid="AutoCheck.Core.Connectors.GDrive.DeleteFolder(System.String)">DeleteFolder(String)</h4>
@@ -1051,7 +1051,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_GDrive_DeleteFolder_System_String_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.GDrive.DeleteFolder(System.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/GDrive.cs/#L220">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/GDrive.cs/#L220">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_GDrive_DeleteFolder_" data-uid="AutoCheck.Core.Connectors.GDrive.DeleteFolder*"></a>
   <h4 id="AutoCheck_Core_Connectors_GDrive_DeleteFolder_System_String_System_String_" data-uid="AutoCheck.Core.Connectors.GDrive.DeleteFolder(System.String,System.String)">DeleteFolder(String, String)</h4>
@@ -1091,7 +1091,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_GDrive_Dispose.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.GDrive.Dispose%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/GDrive.cs/#L97">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/GDrive.cs/#L97">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_GDrive_Dispose_" data-uid="AutoCheck.Core.Connectors.GDrive.Dispose*"></a>
   <h4 id="AutoCheck_Core_Connectors_GDrive_Dispose" data-uid="AutoCheck.Core.Connectors.GDrive.Dispose">Dispose()</h4>
@@ -1109,7 +1109,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_GDrive_Download_Google_Apis_Drive_v3_Data_File_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.GDrive.Download(Google.Apis.Drive.v3.Data.File%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/GDrive.cs/#L580">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/GDrive.cs/#L580">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_GDrive_Download_" data-uid="AutoCheck.Core.Connectors.GDrive.Download*"></a>
   <h4 id="AutoCheck_Core_Connectors_GDrive_Download_Google_Apis_Drive_v3_Data_File_System_String_" data-uid="AutoCheck.Core.Connectors.GDrive.Download(Google.Apis.Drive.v3.Data.File,System.String)">Download(Google.Apis.Drive.v3.Data.File, String)</h4>
@@ -1161,7 +1161,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_GDrive_Download_System_String_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.GDrive.Download(System.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/GDrive.cs/#L592">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/GDrive.cs/#L592">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_GDrive_Download_" data-uid="AutoCheck.Core.Connectors.GDrive.Download*"></a>
   <h4 id="AutoCheck_Core_Connectors_GDrive_Download_System_String_System_String_" data-uid="AutoCheck.Core.Connectors.GDrive.Download(System.String,System.String)">Download(String, String)</h4>
@@ -1213,7 +1213,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_GDrive_Download_Uri_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.GDrive.Download(Uri%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/GDrive.cs/#L565">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/GDrive.cs/#L565">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_GDrive_Download_" data-uid="AutoCheck.Core.Connectors.GDrive.Download*"></a>
   <h4 id="AutoCheck_Core_Connectors_GDrive_Download_Uri_System_String_" data-uid="AutoCheck.Core.Connectors.GDrive.Download(Uri,System.String)">Download(Uri, String)</h4>
@@ -1265,7 +1265,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_GDrive_DownloadFromFile_System_String_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.GDrive.DownloadFromFile(System.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/GDrive.cs/#L629">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/GDrive.cs/#L629">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_GDrive_DownloadFromFile_" data-uid="AutoCheck.Core.Connectors.GDrive.DownloadFromFile*"></a>
   <h4 id="AutoCheck_Core_Connectors_GDrive_DownloadFromFile_System_String_System_String_" data-uid="AutoCheck.Core.Connectors.GDrive.DownloadFromFile(System.String,System.String)">DownloadFromFile(String, String)</h4>
@@ -1317,7 +1317,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_GDrive_ExistsFile_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.GDrive.ExistsFile(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/GDrive.cs/#L647">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/GDrive.cs/#L647">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_GDrive_ExistsFile_" data-uid="AutoCheck.Core.Connectors.GDrive.ExistsFile*"></a>
   <h4 id="AutoCheck_Core_Connectors_GDrive_ExistsFile_System_String_" data-uid="AutoCheck.Core.Connectors.GDrive.ExistsFile(System.String)">ExistsFile(String)</h4>
@@ -1366,7 +1366,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_GDrive_ExistsFile_System_String_System_String_System_Boolean_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.GDrive.ExistsFile(System.String%2CSystem.String%2CSystem.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/GDrive.cs/#L658">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/GDrive.cs/#L658">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_GDrive_ExistsFile_" data-uid="AutoCheck.Core.Connectors.GDrive.ExistsFile*"></a>
   <h4 id="AutoCheck_Core_Connectors_GDrive_ExistsFile_System_String_System_String_System_Boolean_" data-uid="AutoCheck.Core.Connectors.GDrive.ExistsFile(System.String,System.String,System.Boolean)">ExistsFile(String, String, Boolean)</h4>
@@ -1428,7 +1428,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_GDrive_ExistsFolder_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.GDrive.ExistsFolder(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/GDrive.cs/#L233">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/GDrive.cs/#L233">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_GDrive_ExistsFolder_" data-uid="AutoCheck.Core.Connectors.GDrive.ExistsFolder*"></a>
   <h4 id="AutoCheck_Core_Connectors_GDrive_ExistsFolder_System_String_" data-uid="AutoCheck.Core.Connectors.GDrive.ExistsFolder(System.String)">ExistsFolder(String)</h4>
@@ -1477,7 +1477,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_GDrive_ExistsFolder_System_String_System_String_System_Boolean_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.GDrive.ExistsFolder(System.String%2CSystem.String%2CSystem.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/GDrive.cs/#L246">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/GDrive.cs/#L246">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_GDrive_ExistsFolder_" data-uid="AutoCheck.Core.Connectors.GDrive.ExistsFolder*"></a>
   <h4 id="AutoCheck_Core_Connectors_GDrive_ExistsFolder_System_String_System_String_System_Boolean_" data-uid="AutoCheck.Core.Connectors.GDrive.ExistsFolder(System.String,System.String,System.Boolean)">ExistsFolder(String, String, Boolean)</h4>
@@ -1539,7 +1539,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_GDrive_GetFile_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.GDrive.GetFile(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/GDrive.cs/#L316">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/GDrive.cs/#L316">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_GDrive_GetFile_" data-uid="AutoCheck.Core.Connectors.GDrive.GetFile*"></a>
   <h4 id="AutoCheck_Core_Connectors_GDrive_GetFile_System_String_" data-uid="AutoCheck.Core.Connectors.GDrive.GetFile(System.String)">GetFile(String)</h4>
@@ -1588,7 +1588,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_GDrive_GetFile_System_String_System_String_System_Boolean_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.GDrive.GetFile(System.String%2CSystem.String%2CSystem.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/GDrive.cs/#L327">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/GDrive.cs/#L327">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_GDrive_GetFile_" data-uid="AutoCheck.Core.Connectors.GDrive.GetFile*"></a>
   <h4 id="AutoCheck_Core_Connectors_GDrive_GetFile_System_String_System_String_System_Boolean_" data-uid="AutoCheck.Core.Connectors.GDrive.GetFile(System.String,System.String,System.Boolean)">GetFile(String, String, Boolean)</h4>
@@ -1650,7 +1650,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_GDrive_GetFolder_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.GDrive.GetFolder(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/GDrive.cs/#L164">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/GDrive.cs/#L164">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_GDrive_GetFolder_" data-uid="AutoCheck.Core.Connectors.GDrive.GetFolder*"></a>
   <h4 id="AutoCheck_Core_Connectors_GDrive_GetFolder_System_String_" data-uid="AutoCheck.Core.Connectors.GDrive.GetFolder(System.String)">GetFolder(String)</h4>
@@ -1699,7 +1699,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_GDrive_GetFolder_System_String_System_String_System_Boolean_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.GDrive.GetFolder(System.String%2CSystem.String%2CSystem.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/GDrive.cs/#L177">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/GDrive.cs/#L177">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_GDrive_GetFolder_" data-uid="AutoCheck.Core.Connectors.GDrive.GetFolder*"></a>
   <h4 id="AutoCheck_Core_Connectors_GDrive_GetFolder_System_String_System_String_System_Boolean_" data-uid="AutoCheck.Core.Connectors.GDrive.GetFolder(System.String,System.String,System.Boolean)">GetFolder(String, String, Boolean)</h4>
@@ -1761,7 +1761,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_GDrive_UploadFile_System_String_System_String_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.GDrive.UploadFile(System.String%2CSystem.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/GDrive.cs/#L554">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/GDrive.cs/#L554">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_GDrive_UploadFile_" data-uid="AutoCheck.Core.Connectors.GDrive.UploadFile*"></a>
   <h4 id="AutoCheck_Core_Connectors_GDrive_UploadFile_System_String_System_String_System_String_" data-uid="AutoCheck.Core.Connectors.GDrive.UploadFile(System.String,System.String,System.String)">UploadFile(String, String, String)</h4>
@@ -1810,7 +1810,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_GDrive_UploadFolder_System_String_System_String_System_Boolean_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.GDrive.UploadFolder(System.String%2CSystem.String%2CSystem.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/GDrive.cs/#L256">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/GDrive.cs/#L256">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_GDrive_UploadFolder_" data-uid="AutoCheck.Core.Connectors.GDrive.UploadFolder*"></a>
   <h4 id="AutoCheck_Core_Connectors_GDrive_UploadFolder_System_String_System_String_System_Boolean_" data-uid="AutoCheck.Core.Connectors.GDrive.UploadFolder(System.String,System.String,System.Boolean)">UploadFolder(String, String, Boolean)</h4>
@@ -1856,7 +1856,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_GDrive_UploadFolder_System_String_System_String_System_String_System_Boolean_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.GDrive.UploadFolder(System.String%2CSystem.String%2CSystem.String%2CSystem.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/GDrive.cs/#L267">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/GDrive.cs/#L267">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_GDrive_UploadFolder_" data-uid="AutoCheck.Core.Connectors.GDrive.UploadFolder*"></a>
   <h4 id="AutoCheck_Core_Connectors_GDrive_UploadFolder_System_String_System_String_System_String_System_Boolean_" data-uid="AutoCheck.Core.Connectors.GDrive.UploadFolder(System.String,System.String,System.String,System.Boolean)">UploadFolder(String, String, String, Boolean)</h4>
@@ -1918,7 +1918,7 @@
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_GDrive.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.GDrive%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/GDrive.cs/#L43" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/GDrive.cs/#L43" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.Connectors.Html.html
+++ b/docs/html/api/AutoCheck.Core.Connectors.Html.html
@@ -304,7 +304,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Html__ctor_AutoCheck_Core_Utils_OS_System_String_System_String_System_String_System_Int32_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Html.%23ctor(AutoCheck.Core.Utils.OS%2CSystem.String%2CSystem.String%2CSystem.String%2CSystem.Int32%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Html.cs/#L68">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Html.cs/#L68">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Html__ctor_" data-uid="AutoCheck.Core.Connectors.Html.#ctor*"></a>
   <h4 id="AutoCheck_Core_Connectors_Html__ctor_AutoCheck_Core_Utils_OS_System_String_System_String_System_String_System_Int32_System_String_" data-uid="AutoCheck.Core.Connectors.Html.#ctor(AutoCheck.Core.Utils.OS,System.String,System.String,System.String,System.Int32,System.String)">Html(Utils.OS, String, String, String, Int32, String)</h4>
@@ -361,7 +361,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Html__ctor_AutoCheck_Core_Utils_OS_System_String_System_String_System_String_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Html.%23ctor(AutoCheck.Core.Utils.OS%2CSystem.String%2CSystem.String%2CSystem.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Html.cs/#L82">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Html.cs/#L82">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Html__ctor_" data-uid="AutoCheck.Core.Connectors.Html.#ctor*"></a>
   <h4 id="AutoCheck_Core_Connectors_Html__ctor_AutoCheck_Core_Utils_OS_System_String_System_String_System_String_System_String_" data-uid="AutoCheck.Core.Connectors.Html.#ctor(AutoCheck.Core.Utils.OS,System.String,System.String,System.String,System.String)">Html(Utils.OS, String, String, String, String)</h4>
@@ -413,7 +413,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Html__ctor_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Html.%23ctor(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Html.cs/#L55">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Html.cs/#L55">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Html__ctor_" data-uid="AutoCheck.Core.Connectors.Html.#ctor*"></a>
   <h4 id="AutoCheck_Core_Connectors_Html__ctor_System_String_" data-uid="AutoCheck.Core.Connectors.Html.#ctor(System.String)">Html(String)</h4>
@@ -449,7 +449,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Html_HtmlDoc.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Html.HtmlDoc%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Html.cs/#L43">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Html.cs/#L43">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Html_HtmlDoc_" data-uid="AutoCheck.Core.Connectors.Html.HtmlDoc*"></a>
   <h4 id="AutoCheck_Core_Connectors_Html_HtmlDoc" data-uid="AutoCheck.Core.Connectors.Html.HtmlDoc">HtmlDoc</h4>
@@ -480,7 +480,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Html_Raw.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Html.Raw%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Html.cs/#L49">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Html.cs/#L49">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Html_Raw_" data-uid="AutoCheck.Core.Connectors.Html.Raw*"></a>
   <h4 id="AutoCheck_Core_Connectors_Html_Raw" data-uid="AutoCheck.Core.Connectors.Html.Raw">Raw</h4>
@@ -513,7 +513,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Html_ContentLength_HtmlNode_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Html.ContentLength(HtmlNode%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Html.cs/#L241">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Html.cs/#L241">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Html_ContentLength_" data-uid="AutoCheck.Core.Connectors.Html.ContentLength*"></a>
   <h4 id="AutoCheck_Core_Connectors_Html_ContentLength_HtmlNode_System_String_" data-uid="AutoCheck.Core.Connectors.Html.ContentLength(HtmlNode,System.String)">ContentLength(HtmlNode, String)</h4>
@@ -569,7 +569,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Html_ContentLength_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Html.ContentLength(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Html.cs/#L231">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Html.cs/#L231">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Html_ContentLength_" data-uid="AutoCheck.Core.Connectors.Html.ContentLength*"></a>
   <h4 id="AutoCheck_Core_Connectors_Html_ContentLength_System_String_" data-uid="AutoCheck.Core.Connectors.Html.ContentLength(System.String)">ContentLength(String)</h4>
@@ -619,7 +619,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Html_CountNodes_HtmlNode_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Html.CountNodes(HtmlNode%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Html.cs/#L173">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Html.cs/#L173">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Html_CountNodes_" data-uid="AutoCheck.Core.Connectors.Html.CountNodes*"></a>
   <h4 id="AutoCheck_Core_Connectors_Html_CountNodes_HtmlNode_System_String_" data-uid="AutoCheck.Core.Connectors.Html.CountNodes(HtmlNode,System.String)">CountNodes(HtmlNode, String)</h4>
@@ -675,7 +675,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Html_CountNodes_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Html.CountNodes(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Html.cs/#L163">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Html.cs/#L163">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Html_CountNodes_" data-uid="AutoCheck.Core.Connectors.Html.CountNodes*"></a>
   <h4 id="AutoCheck_Core_Connectors_Html_CountNodes_System_String_" data-uid="AutoCheck.Core.Connectors.Html.CountNodes(System.String)">CountNodes(String)</h4>
@@ -725,7 +725,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Html_CountRelatedLabels_HtmlNode_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Html.CountRelatedLabels(HtmlNode%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Html.cs/#L296">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Html.cs/#L296">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Html_CountRelatedLabels_" data-uid="AutoCheck.Core.Connectors.Html.CountRelatedLabels*"></a>
   <h4 id="AutoCheck_Core_Connectors_Html_CountRelatedLabels_HtmlNode_System_String_" data-uid="AutoCheck.Core.Connectors.Html.CountRelatedLabels(HtmlNode,System.String)">CountRelatedLabels(HtmlNode, String)</h4>
@@ -781,7 +781,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Html_CountRelatedLabels_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Html.CountRelatedLabels(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Html.cs/#L286">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Html.cs/#L286">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Html_CountRelatedLabels_" data-uid="AutoCheck.Core.Connectors.Html.CountRelatedLabels*"></a>
   <h4 id="AutoCheck_Core_Connectors_Html_CountRelatedLabels_System_String_" data-uid="AutoCheck.Core.Connectors.Html.CountRelatedLabels(System.String)">CountRelatedLabels(String)</h4>
@@ -831,7 +831,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Html_CountSiblings_HtmlNode_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Html.CountSiblings(HtmlNode%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Html.cs/#L222">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Html.cs/#L222">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Html_CountSiblings_" data-uid="AutoCheck.Core.Connectors.Html.CountSiblings*"></a>
   <h4 id="AutoCheck_Core_Connectors_Html_CountSiblings_HtmlNode_System_String_" data-uid="AutoCheck.Core.Connectors.Html.CountSiblings(HtmlNode,System.String)">CountSiblings(HtmlNode, String)</h4>
@@ -887,7 +887,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Html_CountSiblings_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Html.CountSiblings(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Html.cs/#L212">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Html.cs/#L212">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Html_CountSiblings_" data-uid="AutoCheck.Core.Connectors.Html.CountSiblings*"></a>
   <h4 id="AutoCheck_Core_Connectors_Html_CountSiblings_System_String_" data-uid="AutoCheck.Core.Connectors.Html.CountSiblings(System.String)">CountSiblings(String)</h4>
@@ -937,7 +937,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Html_Dispose.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Html.Dispose%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Html.cs/#L97">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Html.cs/#L97">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Html_Dispose_" data-uid="AutoCheck.Core.Connectors.Html.Dispose*"></a>
   <h4 id="AutoCheck_Core_Connectors_Html_Dispose" data-uid="AutoCheck.Core.Connectors.Html.Dispose">Dispose()</h4>
@@ -955,7 +955,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Html_GetRelatedLabels_HtmlNode_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Html.GetRelatedLabels(HtmlNode%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Html.cs/#L264">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Html.cs/#L264">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Html_GetRelatedLabels_" data-uid="AutoCheck.Core.Connectors.Html.GetRelatedLabels*"></a>
   <h4 id="AutoCheck_Core_Connectors_Html_GetRelatedLabels_HtmlNode_System_String_" data-uid="AutoCheck.Core.Connectors.Html.GetRelatedLabels(HtmlNode,System.String)">GetRelatedLabels(HtmlNode, String)</h4>
@@ -1011,7 +1011,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Html_GetRelatedLabels_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Html.GetRelatedLabels(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Html.cs/#L254">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Html.cs/#L254">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Html_GetRelatedLabels_" data-uid="AutoCheck.Core.Connectors.Html.GetRelatedLabels*"></a>
   <h4 id="AutoCheck_Core_Connectors_Html_GetRelatedLabels_System_String_" data-uid="AutoCheck.Core.Connectors.Html.GetRelatedLabels(System.String)">GetRelatedLabels(String)</h4>
@@ -1061,7 +1061,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Html_GroupSiblings_HtmlNode_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Html.GroupSiblings(HtmlNode%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Html.cs/#L196">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Html.cs/#L196">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Html_GroupSiblings_" data-uid="AutoCheck.Core.Connectors.Html.GroupSiblings*"></a>
   <h4 id="AutoCheck_Core_Connectors_Html_GroupSiblings_HtmlNode_System_String_" data-uid="AutoCheck.Core.Connectors.Html.GroupSiblings(HtmlNode,System.String)">GroupSiblings(HtmlNode, String)</h4>
@@ -1117,7 +1117,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Html_GroupSiblings_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Html.GroupSiblings(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Html.cs/#L186">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Html.cs/#L186">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Html_GroupSiblings_" data-uid="AutoCheck.Core.Connectors.Html.GroupSiblings*"></a>
   <h4 id="AutoCheck_Core_Connectors_Html_GroupSiblings_System_String_" data-uid="AutoCheck.Core.Connectors.Html.GroupSiblings(System.String)">GroupSiblings(String)</h4>
@@ -1167,7 +1167,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Html_SelectNodes_HtmlNode_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Html.SelectNodes(HtmlNode%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Html.cs/#L153">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Html.cs/#L153">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Html_SelectNodes_" data-uid="AutoCheck.Core.Connectors.Html.SelectNodes*"></a>
   <h4 id="AutoCheck_Core_Connectors_Html_SelectNodes_HtmlNode_System_String_" data-uid="AutoCheck.Core.Connectors.Html.SelectNodes(HtmlNode,System.String)">SelectNodes(HtmlNode, String)</h4>
@@ -1223,7 +1223,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Html_SelectNodes_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Html.SelectNodes(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Html.cs/#L143">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Html.cs/#L143">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Html_SelectNodes_" data-uid="AutoCheck.Core.Connectors.Html.SelectNodes*"></a>
   <h4 id="AutoCheck_Core_Connectors_Html_SelectNodes_System_String_" data-uid="AutoCheck.Core.Connectors.Html.SelectNodes(System.String)">SelectNodes(String)</h4>
@@ -1273,7 +1273,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Html_ValidateHtml5AgainstW3C.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Html.ValidateHtml5AgainstW3C%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Html.cs/#L104">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Html.cs/#L104">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Html_ValidateHtml5AgainstW3C_" data-uid="AutoCheck.Core.Connectors.Html.ValidateHtml5AgainstW3C*"></a>
   <h4 id="AutoCheck_Core_Connectors_Html_ValidateHtml5AgainstW3C" data-uid="AutoCheck.Core.Connectors.Html.ValidateHtml5AgainstW3C">ValidateHtml5AgainstW3C()</h4>
@@ -1290,7 +1290,7 @@ Throws an exception if the document is invalid.</p>
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Html_ValidateTable_HtmlNode_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Html.ValidateTable(HtmlNode%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Html.cs/#L315">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Html.cs/#L315">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Html_ValidateTable_" data-uid="AutoCheck.Core.Connectors.Html.ValidateTable*"></a>
   <h4 id="AutoCheck_Core_Connectors_Html_ValidateTable_HtmlNode_System_String_" data-uid="AutoCheck.Core.Connectors.Html.ValidateTable(HtmlNode,System.String)">ValidateTable(HtmlNode, String)</h4>
@@ -1331,7 +1331,7 @@ Throws an exception if it's inconsistent.</p>
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Html_ValidateTable_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Html.ValidateTable(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Html.cs/#L305">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Html.cs/#L305">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Html_ValidateTable_" data-uid="AutoCheck.Core.Connectors.Html.ValidateTable*"></a>
   <h4 id="AutoCheck_Core_Connectors_Html_ValidateTable_System_String_" data-uid="AutoCheck.Core.Connectors.Html.ValidateTable(System.String)">ValidateTable(String)</h4>
@@ -1376,7 +1376,7 @@ Throws an exception if it's inconsistent.</p>
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Html.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Html%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Html.cs/#L38" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Html.cs/#L38" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.Connectors.Math.html
+++ b/docs/html/api/AutoCheck.Core.Connectors.Math.html
@@ -304,7 +304,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Math_Dispose.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Math.Dispose%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Math.cs/#L31">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Math.cs/#L31">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Math_Dispose_" data-uid="AutoCheck.Core.Connectors.Math.Dispose*"></a>
   <h4 id="AutoCheck_Core_Connectors_Math_Dispose" data-uid="AutoCheck.Core.Connectors.Math.Dispose">Dispose()</h4>
@@ -322,7 +322,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Math_Evaluate_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Math.Evaluate(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Math.cs/#L41">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Math.cs/#L41">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Math_Evaluate_" data-uid="AutoCheck.Core.Connectors.Math.Evaluate*"></a>
   <h4 id="AutoCheck_Core_Connectors_Math_Evaluate_System_String_" data-uid="AutoCheck.Core.Connectors.Math.Evaluate(System.String)">Evaluate(String)</h4>
@@ -388,7 +388,7 @@
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Math.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Math%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Math.cs/#L27" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Math.cs/#L27" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.Connectors.Odoo.html
+++ b/docs/html/api/AutoCheck.Core.Connectors.Odoo.html
@@ -416,7 +416,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Odoo__ctor_System_Int32_System_String_System_String_System_String_System_String_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Odoo.%23ctor(System.Int32%2CSystem.String%2CSystem.String%2CSystem.String%2CSystem.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Odoo.cs/#L98">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Odoo.cs/#L98">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Odoo__ctor_" data-uid="AutoCheck.Core.Connectors.Odoo.#ctor*"></a>
   <h4 id="AutoCheck_Core_Connectors_Odoo__ctor_System_Int32_System_String_System_String_System_String_System_String_System_String_" data-uid="AutoCheck.Core.Connectors.Odoo.#ctor(System.Int32,System.String,System.String,System.String,System.String,System.String)">Odoo(Int32, String, String, String, String, String)</h4>
@@ -479,7 +479,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Odoo__ctor_System_String_System_String_System_String_System_String_System_String_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Odoo.%23ctor(System.String%2CSystem.String%2CSystem.String%2CSystem.String%2CSystem.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Odoo.cs/#L113">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Odoo.cs/#L113">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Odoo__ctor_" data-uid="AutoCheck.Core.Connectors.Odoo.#ctor*"></a>
   <h4 id="AutoCheck_Core_Connectors_Odoo__ctor_System_String_System_String_System_String_System_String_System_String_System_String_" data-uid="AutoCheck.Core.Connectors.Odoo.#ctor(System.String,System.String,System.String,System.String,System.String,System.String)">Odoo(String, String, String, String, String, String)</h4>
@@ -544,7 +544,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Odoo_CompanyID.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Odoo.CompanyID%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Odoo.cs/#L39">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Odoo.cs/#L39">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Odoo_CompanyID_" data-uid="AutoCheck.Core.Connectors.Odoo.CompanyID*"></a>
   <h4 id="AutoCheck_Core_Connectors_Odoo_CompanyID" data-uid="AutoCheck.Core.Connectors.Odoo.CompanyID">CompanyID</h4>
@@ -575,7 +575,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Odoo_CompanyName.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Odoo.CompanyName%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Odoo.cs/#L61">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Odoo.cs/#L61">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Odoo_CompanyName_" data-uid="AutoCheck.Core.Connectors.Odoo.CompanyName*"></a>
   <h4 id="AutoCheck_Core_Connectors_Odoo_CompanyName" data-uid="AutoCheck.Core.Connectors.Odoo.CompanyName">CompanyName</h4>
@@ -608,7 +608,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Odoo_GetCompanyData_System_Int32_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Odoo.GetCompanyData(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Odoo.cs/#L149">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Odoo.cs/#L149">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Odoo_GetCompanyData_" data-uid="AutoCheck.Core.Connectors.Odoo.GetCompanyData*"></a>
   <h4 id="AutoCheck_Core_Connectors_Odoo_GetCompanyData_System_Int32_" data-uid="AutoCheck.Core.Connectors.Odoo.GetCompanyData(System.Int32)">GetCompanyData(Int32)</h4>
@@ -658,7 +658,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Odoo_GetCompanyData_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Odoo.GetCompanyData(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Odoo.cs/#L139">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Odoo.cs/#L139">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Odoo_GetCompanyData_" data-uid="AutoCheck.Core.Connectors.Odoo.GetCompanyData*"></a>
   <h4 id="AutoCheck_Core_Connectors_Odoo_GetCompanyData_System_String_" data-uid="AutoCheck.Core.Connectors.Odoo.GetCompanyData(System.String)">GetCompanyData(String)</h4>
@@ -708,7 +708,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Odoo_GetCompanyID_System_String_System_Boolean_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Odoo.GetCompanyID(System.String%2CSystem.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Odoo.cs/#L126">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Odoo.cs/#L126">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Odoo_GetCompanyID_" data-uid="AutoCheck.Core.Connectors.Odoo.GetCompanyID*"></a>
   <h4 id="AutoCheck_Core_Connectors_Odoo_GetCompanyID_System_String_System_Boolean_" data-uid="AutoCheck.Core.Connectors.Odoo.GetCompanyID(System.String,System.Boolean)">GetCompanyID(String, Boolean)</h4>
@@ -764,7 +764,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Odoo_GetInvoiceCode_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Odoo.GetInvoiceCode(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Odoo.cs/#L509">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Odoo.cs/#L509">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Odoo_GetInvoiceCode_" data-uid="AutoCheck.Core.Connectors.Odoo.GetInvoiceCode*"></a>
   <h4 id="AutoCheck_Core_Connectors_Odoo_GetInvoiceCode_System_String_" data-uid="AutoCheck.Core.Connectors.Odoo.GetInvoiceCode(System.String)">GetInvoiceCode(String)</h4>
@@ -814,7 +814,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Odoo_GetInvoiceData_System_Int32_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Odoo.GetInvoiceData(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Odoo.cs/#L519">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Odoo.cs/#L519">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Odoo_GetInvoiceData_" data-uid="AutoCheck.Core.Connectors.Odoo.GetInvoiceData*"></a>
   <h4 id="AutoCheck_Core_Connectors_Odoo_GetInvoiceData_System_Int32_" data-uid="AutoCheck.Core.Connectors.Odoo.GetInvoiceData(System.Int32)">GetInvoiceData(Int32)</h4>
@@ -864,7 +864,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Odoo_GetInvoiceData_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Odoo.GetInvoiceData(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Odoo.cs/#L529">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Odoo.cs/#L529">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Odoo_GetInvoiceData_" data-uid="AutoCheck.Core.Connectors.Odoo.GetInvoiceData*"></a>
   <h4 id="AutoCheck_Core_Connectors_Odoo_GetInvoiceData_System_String_" data-uid="AutoCheck.Core.Connectors.Odoo.GetInvoiceData(System.String)">GetInvoiceData(String)</h4>
@@ -914,7 +914,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Odoo_GetInvoiceID_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Odoo.GetInvoiceID(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Odoo.cs/#L499">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Odoo.cs/#L499">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Odoo_GetInvoiceID_" data-uid="AutoCheck.Core.Connectors.Odoo.GetInvoiceID*"></a>
   <h4 id="AutoCheck_Core_Connectors_Odoo_GetInvoiceID_System_String_" data-uid="AutoCheck.Core.Connectors.Odoo.GetInvoiceID(System.String)">GetInvoiceID(String)</h4>
@@ -964,7 +964,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Odoo_GetLastPosSaleID.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Odoo.GetLastPosSaleID%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Odoo.cs/#L399">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Odoo.cs/#L399">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Odoo_GetLastPosSaleID_" data-uid="AutoCheck.Core.Connectors.Odoo.GetLastPosSaleID*"></a>
   <h4 id="AutoCheck_Core_Connectors_Odoo_GetLastPosSaleID" data-uid="AutoCheck.Core.Connectors.Odoo.GetLastPosSaleID">GetLastPosSaleID()</h4>
@@ -996,7 +996,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Odoo_GetLastPurchaseID.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Odoo.GetLastPurchaseID%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Odoo.cs/#L273">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Odoo.cs/#L273">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Odoo_GetLastPurchaseID_" data-uid="AutoCheck.Core.Connectors.Odoo.GetLastPurchaseID*"></a>
   <h4 id="AutoCheck_Core_Connectors_Odoo_GetLastPurchaseID" data-uid="AutoCheck.Core.Connectors.Odoo.GetLastPurchaseID">GetLastPurchaseID()</h4>
@@ -1028,7 +1028,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Odoo_GetLastSaleID.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Odoo.GetLastSaleID%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Odoo.cs/#L336">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Odoo.cs/#L336">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Odoo_GetLastSaleID_" data-uid="AutoCheck.Core.Connectors.Odoo.GetLastSaleID*"></a>
   <h4 id="AutoCheck_Core_Connectors_Odoo_GetLastSaleID" data-uid="AutoCheck.Core.Connectors.Odoo.GetLastSaleID">GetLastSaleID()</h4>
@@ -1060,7 +1060,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Odoo_GetPosSaleCode_System_Int32_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Odoo.GetPosSaleCode(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Odoo.cs/#L419">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Odoo.cs/#L419">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Odoo_GetPosSaleCode_" data-uid="AutoCheck.Core.Connectors.Odoo.GetPosSaleCode*"></a>
   <h4 id="AutoCheck_Core_Connectors_Odoo_GetPosSaleCode_System_Int32_" data-uid="AutoCheck.Core.Connectors.Odoo.GetPosSaleCode(System.Int32)">GetPosSaleCode(Int32)</h4>
@@ -1110,7 +1110,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Odoo_GetPosSaleData_System_Int32_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Odoo.GetPosSaleData(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Odoo.cs/#L439">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Odoo.cs/#L439">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Odoo_GetPosSaleData_" data-uid="AutoCheck.Core.Connectors.Odoo.GetPosSaleData*"></a>
   <h4 id="AutoCheck_Core_Connectors_Odoo_GetPosSaleData_System_Int32_" data-uid="AutoCheck.Core.Connectors.Odoo.GetPosSaleData(System.Int32)">GetPosSaleData(Int32)</h4>
@@ -1159,7 +1159,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Odoo_GetPosSaleData_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Odoo.GetPosSaleData(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Odoo.cs/#L429">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Odoo.cs/#L429">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Odoo_GetPosSaleData_" data-uid="AutoCheck.Core.Connectors.Odoo.GetPosSaleData*"></a>
   <h4 id="AutoCheck_Core_Connectors_Odoo_GetPosSaleData_System_String_" data-uid="AutoCheck.Core.Connectors.Odoo.GetPosSaleData(System.String)">GetPosSaleData(String)</h4>
@@ -1208,7 +1208,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Odoo_GetPosSaleID_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Odoo.GetPosSaleID(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Odoo.cs/#L409">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Odoo.cs/#L409">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Odoo_GetPosSaleID_" data-uid="AutoCheck.Core.Connectors.Odoo.GetPosSaleID*"></a>
   <h4 id="AutoCheck_Core_Connectors_Odoo_GetPosSaleID_System_String_" data-uid="AutoCheck.Core.Connectors.Odoo.GetPosSaleID(System.String)">GetPosSaleID(String)</h4>
@@ -1258,7 +1258,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Odoo_GetProductTemplateData_System_Int32_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Odoo.GetProductTemplateData(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Odoo.cs/#L245">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Odoo.cs/#L245">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Odoo_GetProductTemplateData_" data-uid="AutoCheck.Core.Connectors.Odoo.GetProductTemplateData*"></a>
   <h4 id="AutoCheck_Core_Connectors_Odoo_GetProductTemplateData_System_Int32_" data-uid="AutoCheck.Core.Connectors.Odoo.GetProductTemplateData(System.Int32)">GetProductTemplateData(Int32)</h4>
@@ -1308,7 +1308,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Odoo_GetProductTemplateData_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Odoo.GetProductTemplateData(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Odoo.cs/#L235">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Odoo.cs/#L235">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Odoo_GetProductTemplateData_" data-uid="AutoCheck.Core.Connectors.Odoo.GetProductTemplateData*"></a>
   <h4 id="AutoCheck_Core_Connectors_Odoo_GetProductTemplateData_System_String_" data-uid="AutoCheck.Core.Connectors.Odoo.GetProductTemplateData(System.String)">GetProductTemplateData(String)</h4>
@@ -1358,7 +1358,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Odoo_GetProductTemplateID_System_String_System_Boolean_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Odoo.GetProductTemplateID(System.String%2CSystem.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Odoo.cs/#L222">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Odoo.cs/#L222">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Odoo_GetProductTemplateID_" data-uid="AutoCheck.Core.Connectors.Odoo.GetProductTemplateID*"></a>
   <h4 id="AutoCheck_Core_Connectors_Odoo_GetProductTemplateID_System_String_System_Boolean_" data-uid="AutoCheck.Core.Connectors.Odoo.GetProductTemplateID(System.String,System.Boolean)">GetProductTemplateID(String, Boolean)</h4>
@@ -1414,7 +1414,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Odoo_GetProviderData_System_Int32_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Odoo.GetProviderData(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Odoo.cs/#L197">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Odoo.cs/#L197">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Odoo_GetProviderData_" data-uid="AutoCheck.Core.Connectors.Odoo.GetProviderData*"></a>
   <h4 id="AutoCheck_Core_Connectors_Odoo_GetProviderData_System_Int32_" data-uid="AutoCheck.Core.Connectors.Odoo.GetProviderData(System.Int32)">GetProviderData(Int32)</h4>
@@ -1464,7 +1464,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Odoo_GetProviderData_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Odoo.GetProviderData(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Odoo.cs/#L187">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Odoo.cs/#L187">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Odoo_GetProviderData_" data-uid="AutoCheck.Core.Connectors.Odoo.GetProviderData*"></a>
   <h4 id="AutoCheck_Core_Connectors_Odoo_GetProviderData_System_String_" data-uid="AutoCheck.Core.Connectors.Odoo.GetProviderData(System.String)">GetProviderData(String)</h4>
@@ -1514,7 +1514,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Odoo_GetProviderID_System_String_System_Boolean_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Odoo.GetProviderID(System.String%2CSystem.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Odoo.cs/#L174">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Odoo.cs/#L174">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Odoo_GetProviderID_" data-uid="AutoCheck.Core.Connectors.Odoo.GetProviderID*"></a>
   <h4 id="AutoCheck_Core_Connectors_Odoo_GetProviderID_System_String_System_Boolean_" data-uid="AutoCheck.Core.Connectors.Odoo.GetProviderID(System.String,System.Boolean)">GetProviderID(String, Boolean)</h4>
@@ -1570,7 +1570,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Odoo_GetPurchaseCode_System_Int32_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Odoo.GetPurchaseCode(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Odoo.cs/#L293">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Odoo.cs/#L293">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Odoo_GetPurchaseCode_" data-uid="AutoCheck.Core.Connectors.Odoo.GetPurchaseCode*"></a>
   <h4 id="AutoCheck_Core_Connectors_Odoo_GetPurchaseCode_System_Int32_" data-uid="AutoCheck.Core.Connectors.Odoo.GetPurchaseCode(System.Int32)">GetPurchaseCode(Int32)</h4>
@@ -1620,7 +1620,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Odoo_GetPurchaseData_System_Int32_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Odoo.GetPurchaseData(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Odoo.cs/#L313">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Odoo.cs/#L313">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Odoo_GetPurchaseData_" data-uid="AutoCheck.Core.Connectors.Odoo.GetPurchaseData*"></a>
   <h4 id="AutoCheck_Core_Connectors_Odoo_GetPurchaseData_System_Int32_" data-uid="AutoCheck.Core.Connectors.Odoo.GetPurchaseData(System.Int32)">GetPurchaseData(Int32)</h4>
@@ -1670,7 +1670,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Odoo_GetPurchaseData_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Odoo.GetPurchaseData(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Odoo.cs/#L303">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Odoo.cs/#L303">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Odoo_GetPurchaseData_" data-uid="AutoCheck.Core.Connectors.Odoo.GetPurchaseData*"></a>
   <h4 id="AutoCheck_Core_Connectors_Odoo_GetPurchaseData_System_String_" data-uid="AutoCheck.Core.Connectors.Odoo.GetPurchaseData(System.String)">GetPurchaseData(String)</h4>
@@ -1720,7 +1720,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Odoo_GetPurchaseID_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Odoo.GetPurchaseID(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Odoo.cs/#L283">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Odoo.cs/#L283">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Odoo_GetPurchaseID_" data-uid="AutoCheck.Core.Connectors.Odoo.GetPurchaseID*"></a>
   <h4 id="AutoCheck_Core_Connectors_Odoo_GetPurchaseID_System_String_" data-uid="AutoCheck.Core.Connectors.Odoo.GetPurchaseID(System.String)">GetPurchaseID(String)</h4>
@@ -1770,7 +1770,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Odoo_GetSaleCode_System_Int32_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Odoo.GetSaleCode(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Odoo.cs/#L356">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Odoo.cs/#L356">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Odoo_GetSaleCode_" data-uid="AutoCheck.Core.Connectors.Odoo.GetSaleCode*"></a>
   <h4 id="AutoCheck_Core_Connectors_Odoo_GetSaleCode_System_Int32_" data-uid="AutoCheck.Core.Connectors.Odoo.GetSaleCode(System.Int32)">GetSaleCode(Int32)</h4>
@@ -1820,7 +1820,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Odoo_GetSaleData_System_Int32_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Odoo.GetSaleData(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Odoo.cs/#L376">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Odoo.cs/#L376">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Odoo_GetSaleData_" data-uid="AutoCheck.Core.Connectors.Odoo.GetSaleData*"></a>
   <h4 id="AutoCheck_Core_Connectors_Odoo_GetSaleData_System_Int32_" data-uid="AutoCheck.Core.Connectors.Odoo.GetSaleData(System.Int32)">GetSaleData(Int32)</h4>
@@ -1870,7 +1870,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Odoo_GetSaleData_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Odoo.GetSaleData(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Odoo.cs/#L366">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Odoo.cs/#L366">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Odoo_GetSaleData_" data-uid="AutoCheck.Core.Connectors.Odoo.GetSaleData*"></a>
   <h4 id="AutoCheck_Core_Connectors_Odoo_GetSaleData_System_String_" data-uid="AutoCheck.Core.Connectors.Odoo.GetSaleData(System.String)">GetSaleData(String)</h4>
@@ -1920,7 +1920,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Odoo_GetSaleID_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Odoo.GetSaleID(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Odoo.cs/#L346">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Odoo.cs/#L346">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Odoo_GetSaleID_" data-uid="AutoCheck.Core.Connectors.Odoo.GetSaleID*"></a>
   <h4 id="AutoCheck_Core_Connectors_Odoo_GetSaleID_System_String_" data-uid="AutoCheck.Core.Connectors.Odoo.GetSaleID(System.String)">GetSaleID(String)</h4>
@@ -1970,7 +1970,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Odoo_GetScrappedStockData.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Odoo.GetScrappedStockData%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Odoo.cs/#L483">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Odoo.cs/#L483">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Odoo_GetScrappedStockData_" data-uid="AutoCheck.Core.Connectors.Odoo.GetScrappedStockData*"></a>
   <h4 id="AutoCheck_Core_Connectors_Odoo_GetScrappedStockData" data-uid="AutoCheck.Core.Connectors.Odoo.GetScrappedStockData">GetScrappedStockData()</h4>
@@ -2002,7 +2002,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Odoo_GetStockMovementData_System_String_System_Boolean_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Odoo.GetStockMovementData(System.String%2CSystem.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Odoo.cs/#L465">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Odoo.cs/#L465">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Odoo_GetStockMovementData_" data-uid="AutoCheck.Core.Connectors.Odoo.GetStockMovementData*"></a>
   <h4 id="AutoCheck_Core_Connectors_Odoo_GetStockMovementData_System_String_System_Boolean_" data-uid="AutoCheck.Core.Connectors.Odoo.GetStockMovementData(System.String,System.Boolean)">GetStockMovementData(String, Boolean)</h4>
@@ -2058,7 +2058,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Odoo_GetUserData_System_Int32_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Odoo.GetUserData(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Odoo.cs/#L603">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Odoo.cs/#L603">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Odoo_GetUserData_" data-uid="AutoCheck.Core.Connectors.Odoo.GetUserData*"></a>
   <h4 id="AutoCheck_Core_Connectors_Odoo_GetUserData_System_Int32_" data-uid="AutoCheck.Core.Connectors.Odoo.GetUserData(System.Int32)">GetUserData(Int32)</h4>
@@ -2108,7 +2108,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Odoo_GetUserData_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Odoo.GetUserData(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Odoo.cs/#L593">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Odoo.cs/#L593">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Odoo_GetUserData_" data-uid="AutoCheck.Core.Connectors.Odoo.GetUserData*"></a>
   <h4 id="AutoCheck_Core_Connectors_Odoo_GetUserData_System_String_" data-uid="AutoCheck.Core.Connectors.Odoo.GetUserData(System.String)">GetUserData(String)</h4>
@@ -2158,7 +2158,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Odoo_GetUserID_System_String_System_Boolean_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Odoo.GetUserID(System.String%2CSystem.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Odoo.cs/#L570">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Odoo.cs/#L570">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Odoo_GetUserID_" data-uid="AutoCheck.Core.Connectors.Odoo.GetUserID*"></a>
   <h4 id="AutoCheck_Core_Connectors_Odoo_GetUserID_System_String_System_Boolean_" data-uid="AutoCheck.Core.Connectors.Odoo.GetUserID(System.String,System.Boolean)">GetUserID(String, Boolean)</h4>
@@ -2214,7 +2214,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Odoo_GetUserName_System_Int32_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Odoo.GetUserName(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Odoo.cs/#L583">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Odoo.cs/#L583">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Odoo_GetUserName_" data-uid="AutoCheck.Core.Connectors.Odoo.GetUserName*"></a>
   <h4 id="AutoCheck_Core_Connectors_Odoo_GetUserName_System_Int32_" data-uid="AutoCheck.Core.Connectors.Odoo.GetUserName(System.Int32)">GetUserName(Int32)</h4>
@@ -2274,7 +2274,7 @@
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Odoo.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Odoo%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Odoo.cs/#L30" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Odoo.cs/#L30" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.Connectors.Operator.html
+++ b/docs/html/api/AutoCheck.Core.Connectors.Operator.html
@@ -340,7 +340,7 @@
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Operator.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Operator%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Base.cs/#L28" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Base.cs/#L28" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.Connectors.PlainText.PlainTextDocument.html
+++ b/docs/html/api/AutoCheck.Core.Connectors.PlainText.PlainTextDocument.html
@@ -297,7 +297,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_PlainText_PlainTextDocument__ctor_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.PlainText.PlainTextDocument.%23ctor(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/PlainText.cs/#L59">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/PlainText.cs/#L59">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_PlainText_PlainTextDocument__ctor_" data-uid="AutoCheck.Core.Connectors.PlainText.PlainTextDocument.#ctor*"></a>
   <h4 id="AutoCheck_Core_Connectors_PlainText_PlainTextDocument__ctor_System_String_" data-uid="AutoCheck.Core.Connectors.PlainText.PlainTextDocument.#ctor(System.String)">PlainTextDocument(String)</h4>
@@ -333,7 +333,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_PlainText_PlainTextDocument_Content.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.PlainText.PlainTextDocument.Content%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/PlainText.cs/#L40">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/PlainText.cs/#L40">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_PlainText_PlainTextDocument_Content_" data-uid="AutoCheck.Core.Connectors.PlainText.PlainTextDocument.Content*"></a>
   <h4 id="AutoCheck_Core_Connectors_PlainText_PlainTextDocument_Content" data-uid="AutoCheck.Core.Connectors.PlainText.PlainTextDocument.Content">Content</h4>
@@ -364,7 +364,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_PlainText_PlainTextDocument_Lines.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.PlainText.PlainTextDocument.Lines%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/PlainText.cs/#L49">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/PlainText.cs/#L49">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_PlainText_PlainTextDocument_Lines_" data-uid="AutoCheck.Core.Connectors.PlainText.PlainTextDocument.Lines*"></a>
   <h4 id="AutoCheck_Core_Connectors_PlainText_PlainTextDocument_Lines" data-uid="AutoCheck.Core.Connectors.PlainText.PlainTextDocument.Lines">Lines</h4>
@@ -397,7 +397,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_PlainText_PlainTextDocument_GetLine_System_Int32_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.PlainText.PlainTextDocument.GetLine(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/PlainText.cs/#L71">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/PlainText.cs/#L71">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_PlainText_PlainTextDocument_GetLine_" data-uid="AutoCheck.Core.Connectors.PlainText.PlainTextDocument.GetLine*"></a>
   <h4 id="AutoCheck_Core_Connectors_PlainText_PlainTextDocument_GetLine_System_Int32_" data-uid="AutoCheck.Core.Connectors.PlainText.PlainTextDocument.GetLine(System.Int32)">GetLine(Int32)</h4>
@@ -456,7 +456,7 @@
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_PlainText_PlainTextDocument.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.PlainText.PlainTextDocument%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/PlainText.cs/#L34" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/PlainText.cs/#L34" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.Connectors.PlainText.html
+++ b/docs/html/api/AutoCheck.Core.Connectors.PlainText.html
@@ -304,7 +304,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_PlainText__ctor_AutoCheck_Core_Utils_OS_System_String_System_String_System_String_System_Int32_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.PlainText.%23ctor(AutoCheck.Core.Utils.OS%2CSystem.String%2CSystem.String%2CSystem.String%2CSystem.Int32%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/PlainText.cs/#L101">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/PlainText.cs/#L101">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_PlainText__ctor_" data-uid="AutoCheck.Core.Connectors.PlainText.#ctor*"></a>
   <h4 id="AutoCheck_Core_Connectors_PlainText__ctor_AutoCheck_Core_Utils_OS_System_String_System_String_System_String_System_Int32_System_String_" data-uid="AutoCheck.Core.Connectors.PlainText.#ctor(AutoCheck.Core.Utils.OS,System.String,System.String,System.String,System.Int32,System.String)">PlainText(Utils.OS, String, String, String, Int32, String)</h4>
@@ -361,7 +361,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_PlainText__ctor_AutoCheck_Core_Utils_OS_System_String_System_String_System_String_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.PlainText.%23ctor(AutoCheck.Core.Utils.OS%2CSystem.String%2CSystem.String%2CSystem.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/PlainText.cs/#L115">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/PlainText.cs/#L115">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_PlainText__ctor_" data-uid="AutoCheck.Core.Connectors.PlainText.#ctor*"></a>
   <h4 id="AutoCheck_Core_Connectors_PlainText__ctor_AutoCheck_Core_Utils_OS_System_String_System_String_System_String_System_String_" data-uid="AutoCheck.Core.Connectors.PlainText.#ctor(AutoCheck.Core.Utils.OS,System.String,System.String,System.String,System.String)">PlainText(Utils.OS, String, String, String, String)</h4>
@@ -413,7 +413,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_PlainText__ctor_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.PlainText.%23ctor(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/PlainText.cs/#L88">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/PlainText.cs/#L88">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_PlainText__ctor_" data-uid="AutoCheck.Core.Connectors.PlainText.#ctor*"></a>
   <h4 id="AutoCheck_Core_Connectors_PlainText__ctor_System_String_" data-uid="AutoCheck.Core.Connectors.PlainText.#ctor(System.String)">PlainText(String)</h4>
@@ -449,7 +449,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_PlainText_plainTextDoc.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.PlainText.plainTextDoc%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/PlainText.cs/#L80">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/PlainText.cs/#L80">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_PlainText_plainTextDoc_" data-uid="AutoCheck.Core.Connectors.PlainText.plainTextDoc*"></a>
   <h4 id="AutoCheck_Core_Connectors_PlainText_plainTextDoc" data-uid="AutoCheck.Core.Connectors.PlainText.plainTextDoc">plainTextDoc</h4>
@@ -482,7 +482,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_PlainText_Count_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.PlainText.Count(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/PlainText.cs/#L150">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/PlainText.cs/#L150">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_PlainText_Count_" data-uid="AutoCheck.Core.Connectors.PlainText.Count*"></a>
   <h4 id="AutoCheck_Core_Connectors_PlainText_Count_System_String_" data-uid="AutoCheck.Core.Connectors.PlainText.Count(System.String)">Count(String)</h4>
@@ -532,7 +532,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_PlainText_Dispose.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.PlainText.Dispose%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/PlainText.cs/#L128">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/PlainText.cs/#L128">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_PlainText_Dispose_" data-uid="AutoCheck.Core.Connectors.PlainText.Dispose*"></a>
   <h4 id="AutoCheck_Core_Connectors_PlainText_Dispose" data-uid="AutoCheck.Core.Connectors.PlainText.Dispose">Dispose()</h4>
@@ -550,7 +550,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_PlainText_Find_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.PlainText.Find(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/PlainText.cs/#L136">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/PlainText.cs/#L136">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_PlainText_Find_" data-uid="AutoCheck.Core.Connectors.PlainText.Find*"></a>
   <h4 id="AutoCheck_Core_Connectors_PlainText_Find_System_String_" data-uid="AutoCheck.Core.Connectors.PlainText.Find(System.String)">Find(String)</h4>
@@ -610,7 +610,7 @@
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_PlainText.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.PlainText%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/PlainText.cs/#L30" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/PlainText.cs/#L30" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.Connectors.Postgres.html
+++ b/docs/html/api/AutoCheck.Core.Connectors.Postgres.html
@@ -305,7 +305,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Postgres__ctor_System_String_System_String_System_String_System_String_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Postgres.%23ctor(System.String%2CSystem.String%2CSystem.String%2CSystem.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Postgres.cs/#L83">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Postgres.cs/#L83">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Postgres__ctor_" data-uid="AutoCheck.Core.Connectors.Postgres.#ctor*"></a>
   <h4 id="AutoCheck_Core_Connectors_Postgres__ctor_System_String_System_String_System_String_System_String_System_String_" data-uid="AutoCheck.Core.Connectors.Postgres.#ctor(System.String,System.String,System.String,System.String,System.String)">Postgres(String, String, String, String, String)</h4>
@@ -365,7 +365,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Postgres_BinPath.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Postgres.BinPath%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Postgres.cs/#L71">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Postgres.cs/#L71">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Postgres_BinPath_" data-uid="AutoCheck.Core.Connectors.Postgres.BinPath*"></a>
   <h4 id="AutoCheck_Core_Connectors_Postgres_BinPath" data-uid="AutoCheck.Core.Connectors.Postgres.BinPath">BinPath</h4>
@@ -396,7 +396,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Postgres_Conn.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Postgres.Conn%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Postgres.cs/#L40">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Postgres.cs/#L40">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Postgres_Conn_" data-uid="AutoCheck.Core.Connectors.Postgres.Conn*"></a>
   <h4 id="AutoCheck_Core_Connectors_Postgres_Conn" data-uid="AutoCheck.Core.Connectors.Postgres.Conn">Conn</h4>
@@ -427,7 +427,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Postgres_Database.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Postgres.Database%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Postgres.cs/#L52">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Postgres.cs/#L52">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Postgres_Database_" data-uid="AutoCheck.Core.Connectors.Postgres.Database*"></a>
   <h4 id="AutoCheck_Core_Connectors_Postgres_Database" data-uid="AutoCheck.Core.Connectors.Postgres.Database">Database</h4>
@@ -458,7 +458,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Postgres_Host.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Postgres.Host%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Postgres.cs/#L46">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Postgres.cs/#L46">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Postgres_Host_" data-uid="AutoCheck.Core.Connectors.Postgres.Host*"></a>
   <h4 id="AutoCheck_Core_Connectors_Postgres_Host" data-uid="AutoCheck.Core.Connectors.Postgres.Host">Host</h4>
@@ -489,7 +489,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Postgres_Password.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Postgres.Password%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Postgres.cs/#L65">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Postgres.cs/#L65">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Postgres_Password_" data-uid="AutoCheck.Core.Connectors.Postgres.Password*"></a>
   <h4 id="AutoCheck_Core_Connectors_Postgres_Password" data-uid="AutoCheck.Core.Connectors.Postgres.Password">Password</h4>
@@ -520,7 +520,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Postgres_User.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Postgres.User%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Postgres.cs/#L58">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Postgres.cs/#L58">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Postgres_User_" data-uid="AutoCheck.Core.Connectors.Postgres.User*"></a>
   <h4 id="AutoCheck_Core_Connectors_Postgres_User" data-uid="AutoCheck.Core.Connectors.Postgres.User">User</h4>
@@ -553,7 +553,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Postgres_CompareSelects_System_String_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Postgres.CompareSelects(System.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Postgres.cs/#L554">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Postgres.cs/#L554">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Postgres_CompareSelects_" data-uid="AutoCheck.Core.Connectors.Postgres.CompareSelects*"></a>
   <h4 id="AutoCheck_Core_Connectors_Postgres_CompareSelects_System_String_System_String_" data-uid="AutoCheck.Core.Connectors.Postgres.CompareSelects(System.String,System.String)">CompareSelects(String, String)</h4>
@@ -609,7 +609,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Postgres_CompareSelectWithView_System_String_System_String_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Postgres.CompareSelectWithView(System.String%2CSystem.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Postgres.cs/#L544">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Postgres.cs/#L544">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Postgres_CompareSelectWithView_" data-uid="AutoCheck.Core.Connectors.Postgres.CompareSelectWithView*"></a>
   <h4 id="AutoCheck_Core_Connectors_Postgres_CompareSelectWithView_System_String_System_String_System_String_" data-uid="AutoCheck.Core.Connectors.Postgres.CompareSelectWithView(System.String,System.String,System.String)">CompareSelectWithView(String, String, String)</h4>
@@ -671,7 +671,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Postgres_CountRoles.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Postgres.CountRoles%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Postgres.cs/#L422">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Postgres.cs/#L422">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Postgres_CountRoles_" data-uid="AutoCheck.Core.Connectors.Postgres.CountRoles*"></a>
   <h4 id="AutoCheck_Core_Connectors_Postgres_CountRoles" data-uid="AutoCheck.Core.Connectors.Postgres.CountRoles">CountRoles()</h4>
@@ -703,7 +703,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Postgres_CountUsers.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Postgres.CountUsers%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Postgres.cs/#L361">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Postgres.cs/#L361">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Postgres_CountUsers_" data-uid="AutoCheck.Core.Connectors.Postgres.CountUsers*"></a>
   <h4 id="AutoCheck_Core_Connectors_Postgres_CountUsers" data-uid="AutoCheck.Core.Connectors.Postgres.CountUsers">CountUsers()</h4>
@@ -735,7 +735,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Postgres_CreateDataBase_System_Boolean_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Postgres.CreateDataBase(System.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Postgres.cs/#L238">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Postgres.cs/#L238">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Postgres_CreateDataBase_" data-uid="AutoCheck.Core.Connectors.Postgres.CreateDataBase*"></a>
   <h4 id="AutoCheck_Core_Connectors_Postgres_CreateDataBase_System_Boolean_" data-uid="AutoCheck.Core.Connectors.Postgres.CreateDataBase(System.Boolean)">CreateDataBase(Boolean)</h4>
@@ -769,7 +769,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Postgres_CreateDataBase_System_String_System_Boolean_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Postgres.CreateDataBase(System.String%2CSystem.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Postgres.cs/#L225">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Postgres.cs/#L225">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Postgres_CreateDataBase_" data-uid="AutoCheck.Core.Connectors.Postgres.CreateDataBase*"></a>
   <h4 id="AutoCheck_Core_Connectors_Postgres_CreateDataBase_System_String_System_Boolean_" data-uid="AutoCheck.Core.Connectors.Postgres.CreateDataBase(System.String,System.Boolean)">CreateDataBase(String, Boolean)</h4>
@@ -808,7 +808,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Postgres_CreateRole_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Postgres.CreateRole(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Postgres.cs/#L430">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Postgres.cs/#L430">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Postgres_CreateRole_" data-uid="AutoCheck.Core.Connectors.Postgres.CreateRole*"></a>
   <h4 id="AutoCheck_Core_Connectors_Postgres_CreateRole_System_String_" data-uid="AutoCheck.Core.Connectors.Postgres.CreateRole(System.String)">CreateRole(String)</h4>
@@ -842,7 +842,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Postgres_CreateUser_System_String_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Postgres.CreateUser(System.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Postgres.cs/#L369">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Postgres.cs/#L369">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Postgres_CreateUser_" data-uid="AutoCheck.Core.Connectors.Postgres.CreateUser*"></a>
   <h4 id="AutoCheck_Core_Connectors_Postgres_CreateUser_System_String_System_String_" data-uid="AutoCheck.Core.Connectors.Postgres.CreateUser(System.String,System.String)">CreateUser(String, String)</h4>
@@ -880,7 +880,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Postgres_Dispose.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Postgres.Dispose%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Postgres.cs/#L101">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Postgres.cs/#L101">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Postgres_Dispose_" data-uid="AutoCheck.Core.Connectors.Postgres.Dispose*"></a>
   <h4 id="AutoCheck_Core_Connectors_Postgres_Dispose" data-uid="AutoCheck.Core.Connectors.Postgres.Dispose">Dispose()</h4>
@@ -898,7 +898,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Postgres_DropDataBase.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Postgres.DropDataBase%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Postgres.cs/#L296">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Postgres.cs/#L296">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Postgres_DropDataBase_" data-uid="AutoCheck.Core.Connectors.Postgres.DropDataBase*"></a>
   <h4 id="AutoCheck_Core_Connectors_Postgres_DropDataBase" data-uid="AutoCheck.Core.Connectors.Postgres.DropDataBase">DropDataBase()</h4>
@@ -914,7 +914,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Postgres_DropRole_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Postgres.DropRole(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Postgres.cs/#L439">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Postgres.cs/#L439">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Postgres_DropRole_" data-uid="AutoCheck.Core.Connectors.Postgres.DropRole*"></a>
   <h4 id="AutoCheck_Core_Connectors_Postgres_DropRole_System_String_" data-uid="AutoCheck.Core.Connectors.Postgres.DropRole(System.String)">DropRole(String)</h4>
@@ -948,7 +948,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Postgres_DropRoleMembership_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Postgres.DropRoleMembership(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Postgres.cs/#L461">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Postgres.cs/#L461">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Postgres_DropRoleMembership_" data-uid="AutoCheck.Core.Connectors.Postgres.DropRoleMembership*"></a>
   <h4 id="AutoCheck_Core_Connectors_Postgres_DropRoleMembership_System_String_" data-uid="AutoCheck.Core.Connectors.Postgres.DropRoleMembership(System.String)">DropRoleMembership(String)</h4>
@@ -982,7 +982,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Postgres_DropUser_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Postgres.DropUser(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Postgres.cs/#L381">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Postgres.cs/#L381">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Postgres_DropUser_" data-uid="AutoCheck.Core.Connectors.Postgres.DropUser*"></a>
   <h4 id="AutoCheck_Core_Connectors_Postgres_DropUser_System_String_" data-uid="AutoCheck.Core.Connectors.Postgres.DropUser(System.String)">DropUser(String)</h4>
@@ -1015,7 +1015,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Postgres_DropUserMembership_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Postgres.DropUserMembership(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Postgres.cs/#L403">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Postgres.cs/#L403">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Postgres_DropUserMembership_" data-uid="AutoCheck.Core.Connectors.Postgres.DropUserMembership*"></a>
   <h4 id="AutoCheck_Core_Connectors_Postgres_DropUserMembership_System_String_" data-uid="AutoCheck.Core.Connectors.Postgres.DropUserMembership(System.String)">DropUserMembership(String)</h4>
@@ -1049,7 +1049,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Postgres_ExecuteNonQuery_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Postgres.ExecuteNonQuery(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Postgres.cs/#L163">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Postgres.cs/#L163">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Postgres_ExecuteNonQuery_" data-uid="AutoCheck.Core.Connectors.Postgres.ExecuteNonQuery*"></a>
   <h4 id="AutoCheck_Core_Connectors_Postgres_ExecuteNonQuery_System_String_" data-uid="AutoCheck.Core.Connectors.Postgres.ExecuteNonQuery(System.String)">ExecuteNonQuery(String)</h4>
@@ -1083,7 +1083,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Postgres_ExecuteQuery_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Postgres.ExecuteQuery(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Postgres.cs/#L125">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Postgres.cs/#L125">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Postgres_ExecuteQuery_" data-uid="AutoCheck.Core.Connectors.Postgres.ExecuteQuery*"></a>
   <h4 id="AutoCheck_Core_Connectors_Postgres_ExecuteQuery_System_String_" data-uid="AutoCheck.Core.Connectors.Postgres.ExecuteQuery(System.String)">ExecuteQuery(String)</h4>
@@ -1133,7 +1133,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Postgres_ExecuteScalar__1_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Postgres.ExecuteScalar%60%601(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Postgres.cs/#L185">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Postgres.cs/#L185">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Postgres_ExecuteScalar_" data-uid="AutoCheck.Core.Connectors.Postgres.ExecuteScalar*"></a>
   <h4 id="AutoCheck_Core_Connectors_Postgres_ExecuteScalar__1_System_String_" data-uid="AutoCheck.Core.Connectors.Postgres.ExecuteScalar``1(System.String)">ExecuteScalar&lt;T&gt;(String)</h4>
@@ -1198,7 +1198,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Postgres_ExistsDataBase.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Postgres.ExistsDataBase%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Postgres.cs/#L207">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Postgres.cs/#L207">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Postgres_ExistsDataBase_" data-uid="AutoCheck.Core.Connectors.Postgres.ExistsDataBase*"></a>
   <h4 id="AutoCheck_Core_Connectors_Postgres_ExistsDataBase" data-uid="AutoCheck.Core.Connectors.Postgres.ExistsDataBase">ExistsDataBase()</h4>
@@ -1230,7 +1230,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Postgres_ExistsForeignKey_System_String_System_String_System_String_System_String_System_String_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Postgres.ExistsForeignKey(System.String%2CSystem.String%2CSystem.String%2CSystem.String%2CSystem.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Postgres.cs/#L609">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Postgres.cs/#L609">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Postgres_ExistsForeignKey_" data-uid="AutoCheck.Core.Connectors.Postgres.ExistsForeignKey*"></a>
   <h4 id="AutoCheck_Core_Connectors_Postgres_ExistsForeignKey_System_String_System_String_System_String_System_String_System_String_System_String_" data-uid="AutoCheck.Core.Connectors.Postgres.ExistsForeignKey(System.String,System.String,System.String,System.String,System.String,System.String)">ExistsForeignKey(String, String, String, String, String, String)</h4>
@@ -1310,7 +1310,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Postgres_ExistsRole_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Postgres.ExistsRole(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Postgres.cs/#L450">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Postgres.cs/#L450">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Postgres_ExistsRole_" data-uid="AutoCheck.Core.Connectors.Postgres.ExistsRole*"></a>
   <h4 id="AutoCheck_Core_Connectors_Postgres_ExistsRole_System_String_" data-uid="AutoCheck.Core.Connectors.Postgres.ExistsRole(System.String)">ExistsRole(String)</h4>
@@ -1357,7 +1357,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Postgres_ExistsTable_System_String_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Postgres.ExistsTable(System.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Postgres.cs/#L627">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Postgres.cs/#L627">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Postgres_ExistsTable_" data-uid="AutoCheck.Core.Connectors.Postgres.ExistsTable*"></a>
   <h4 id="AutoCheck_Core_Connectors_Postgres_ExistsTable_System_String_System_String_" data-uid="AutoCheck.Core.Connectors.Postgres.ExistsTable(System.String,System.String)">ExistsTable(String, String)</h4>
@@ -1413,7 +1413,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Postgres_ExistsUser_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Postgres.ExistsUser(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Postgres.cs/#L392">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Postgres.cs/#L392">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Postgres_ExistsUser_" data-uid="AutoCheck.Core.Connectors.Postgres.ExistsUser*"></a>
   <h4 id="AutoCheck_Core_Connectors_Postgres_ExistsUser_System_String_" data-uid="AutoCheck.Core.Connectors.Postgres.ExistsUser(System.String)">ExistsUser(String)</h4>
@@ -1460,7 +1460,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Postgres_GetForeignKeys_System_String_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Postgres.GetForeignKeys(System.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Postgres.cs/#L588">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Postgres.cs/#L588">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Postgres_GetForeignKeys_" data-uid="AutoCheck.Core.Connectors.Postgres.GetForeignKeys*"></a>
   <h4 id="AutoCheck_Core_Connectors_Postgres_GetForeignKeys_System_String_System_String_" data-uid="AutoCheck.Core.Connectors.Postgres.GetForeignKeys(System.String,System.String)">GetForeignKeys(String, String)</h4>
@@ -1516,7 +1516,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Postgres_GetMembership_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Postgres.GetMembership(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Postgres.cs/#L472">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Postgres.cs/#L472">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Postgres_GetMembership_" data-uid="AutoCheck.Core.Connectors.Postgres.GetMembership*"></a>
   <h4 id="AutoCheck_Core_Connectors_Postgres_GetMembership_System_String_" data-uid="AutoCheck.Core.Connectors.Postgres.GetMembership(System.String)">GetMembership(String)</h4>
@@ -1566,7 +1566,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Postgres_GetRoles.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Postgres.GetRoles%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Postgres.cs/#L414">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Postgres.cs/#L414">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Postgres_GetRoles_" data-uid="AutoCheck.Core.Connectors.Postgres.GetRoles*"></a>
   <h4 id="AutoCheck_Core_Connectors_Postgres_GetRoles" data-uid="AutoCheck.Core.Connectors.Postgres.GetRoles">GetRoles()</h4>
@@ -1598,7 +1598,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Postgres_GetSchemaPrivileges_System_String_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Postgres.GetSchemaPrivileges(System.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Postgres.cs/#L520">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Postgres.cs/#L520">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Postgres_GetSchemaPrivileges_" data-uid="AutoCheck.Core.Connectors.Postgres.GetSchemaPrivileges*"></a>
   <h4 id="AutoCheck_Core_Connectors_Postgres_GetSchemaPrivileges_System_String_System_String_" data-uid="AutoCheck.Core.Connectors.Postgres.GetSchemaPrivileges(System.String,System.String)">GetSchemaPrivileges(String, String)</h4>
@@ -1654,7 +1654,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Postgres_GetTablePrivileges_System_String_System_String_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Postgres.GetTablePrivileges(System.String%2CSystem.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Postgres.cs/#L490">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Postgres.cs/#L490">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Postgres_GetTablePrivileges_" data-uid="AutoCheck.Core.Connectors.Postgres.GetTablePrivileges*"></a>
   <h4 id="AutoCheck_Core_Connectors_Postgres_GetTablePrivileges_System_String_System_String_System_String_" data-uid="AutoCheck.Core.Connectors.Postgres.GetTablePrivileges(System.String,System.String,System.String)">GetTablePrivileges(String, String, String)</h4>
@@ -1716,7 +1716,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Postgres_GetUsers.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Postgres.GetUsers%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Postgres.cs/#L343">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Postgres.cs/#L343">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Postgres_GetUsers_" data-uid="AutoCheck.Core.Connectors.Postgres.GetUsers*"></a>
   <h4 id="AutoCheck_Core_Connectors_Postgres_GetUsers" data-uid="AutoCheck.Core.Connectors.Postgres.GetUsers">GetUsers()</h4>
@@ -1748,7 +1748,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Postgres_GetViewDefinition_System_String_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Postgres.GetViewDefinition(System.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Postgres.cs/#L575">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Postgres.cs/#L575">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Postgres_GetViewDefinition_" data-uid="AutoCheck.Core.Connectors.Postgres.GetViewDefinition*"></a>
   <h4 id="AutoCheck_Core_Connectors_Postgres_GetViewDefinition_System_String_System_String_" data-uid="AutoCheck.Core.Connectors.Postgres.GetViewDefinition(System.String,System.String)">GetViewDefinition(String, String)</h4>
@@ -1804,7 +1804,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Postgres_ImportSqlDump_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Postgres.ImportSqlDump(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Postgres.cs/#L266">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Postgres.cs/#L266">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Postgres_ImportSqlDump_" data-uid="AutoCheck.Core.Connectors.Postgres.ImportSqlDump*"></a>
   <h4 id="AutoCheck_Core_Connectors_Postgres_ImportSqlDump_System_String_" data-uid="AutoCheck.Core.Connectors.Postgres.ImportSqlDump(System.String)">ImportSqlDump(String)</h4>
@@ -1837,7 +1837,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Postgres_TestConnection.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Postgres.TestConnection%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Postgres.cs/#L109">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Postgres.cs/#L109">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Postgres_TestConnection_" data-uid="AutoCheck.Core.Connectors.Postgres.TestConnection*"></a>
   <h4 id="AutoCheck_Core_Connectors_Postgres_TestConnection" data-uid="AutoCheck.Core.Connectors.Postgres.TestConnection">TestConnection()</h4>
@@ -1863,7 +1863,7 @@
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Postgres.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Postgres%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Postgres.cs/#L33" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Postgres.cs/#L33" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.Connectors.Rss.html
+++ b/docs/html/api/AutoCheck.Core.Connectors.Rss.html
@@ -333,7 +333,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Rss__ctor_AutoCheck_Core_Utils_OS_System_String_System_String_System_String_System_Int32_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Rss.%23ctor(AutoCheck.Core.Utils.OS%2CSystem.String%2CSystem.String%2CSystem.String%2CSystem.Int32%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Rss.cs/#L48">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Rss.cs/#L48">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Rss__ctor_" data-uid="AutoCheck.Core.Connectors.Rss.#ctor*"></a>
   <h4 id="AutoCheck_Core_Connectors_Rss__ctor_AutoCheck_Core_Utils_OS_System_String_System_String_System_String_System_Int32_System_String_" data-uid="AutoCheck.Core.Connectors.Rss.#ctor(AutoCheck.Core.Utils.OS,System.String,System.String,System.String,System.Int32,System.String)">Rss(Utils.OS, String, String, String, Int32, String)</h4>
@@ -390,7 +390,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Rss__ctor_AutoCheck_Core_Utils_OS_System_String_System_String_System_String_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Rss.%23ctor(AutoCheck.Core.Utils.OS%2CSystem.String%2CSystem.String%2CSystem.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Rss.cs/#L59">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Rss.cs/#L59">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Rss__ctor_" data-uid="AutoCheck.Core.Connectors.Rss.#ctor*"></a>
   <h4 id="AutoCheck_Core_Connectors_Rss__ctor_AutoCheck_Core_Utils_OS_System_String_System_String_System_String_System_String_" data-uid="AutoCheck.Core.Connectors.Rss.#ctor(AutoCheck.Core.Utils.OS,System.String,System.String,System.String,System.String)">Rss(Utils.OS, String, String, String, String)</h4>
@@ -442,7 +442,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Rss__ctor_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Rss.%23ctor(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Rss.cs/#L36">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Rss.cs/#L36">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Rss__ctor_" data-uid="AutoCheck.Core.Connectors.Rss.#ctor*"></a>
   <h4 id="AutoCheck_Core_Connectors_Rss__ctor_System_String_" data-uid="AutoCheck.Core.Connectors.Rss.#ctor(System.String)">Rss(String)</h4>
@@ -478,7 +478,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Rss_Dispose.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Rss.Dispose%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Rss.cs/#L66">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Rss.cs/#L66">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Rss_Dispose_" data-uid="AutoCheck.Core.Connectors.Rss.Dispose*"></a>
   <h4 id="AutoCheck_Core_Connectors_Rss_Dispose" data-uid="AutoCheck.Core.Connectors.Rss.Dispose">Dispose()</h4>
@@ -496,7 +496,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Rss_ValidateRssAgainstW3C.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Rss.ValidateRssAgainstW3C%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Rss.cs/#L74">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Rss.cs/#L74">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Rss_ValidateRssAgainstW3C_" data-uid="AutoCheck.Core.Connectors.Rss.ValidateRssAgainstW3C*"></a>
   <h4 id="AutoCheck_Core_Connectors_Rss_ValidateRssAgainstW3C" data-uid="AutoCheck.Core.Connectors.Rss.ValidateRssAgainstW3C">ValidateRssAgainstW3C()</h4>
@@ -523,7 +523,7 @@ Throws an exception if the document is invalid.</p>
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Rss.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Rss%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Rss.cs/#L31" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Rss.cs/#L31" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.Connectors.Shell.html
+++ b/docs/html/api/AutoCheck.Core.Connectors.Shell.html
@@ -304,7 +304,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Shell__ctor.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Shell.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Shell.cs/#L98">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Shell.cs/#L98">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Shell__ctor_" data-uid="AutoCheck.Core.Connectors.Shell.#ctor*"></a>
   <h4 id="AutoCheck_Core_Connectors_Shell__ctor" data-uid="AutoCheck.Core.Connectors.Shell.#ctor">Shell()</h4>
@@ -320,7 +320,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Shell__ctor_AutoCheck_Core_Utils_OS_System_String_System_String_System_String_System_Int32_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Shell.%23ctor(AutoCheck.Core.Utils.OS%2CSystem.String%2CSystem.String%2CSystem.String%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Shell.cs/#L124">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Shell.cs/#L124">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Shell__ctor_" data-uid="AutoCheck.Core.Connectors.Shell.#ctor*"></a>
   <h4 id="AutoCheck_Core_Connectors_Shell__ctor_AutoCheck_Core_Utils_OS_System_String_System_String_System_String_System_Int32_" data-uid="AutoCheck.Core.Connectors.Shell.#ctor(AutoCheck.Core.Utils.OS,System.String,System.String,System.String,System.Int32)">Shell(Utils.OS, String, String, String, Int32)</h4>
@@ -372,7 +372,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Shell__ctor_System_String_System_String_System_String_System_String_System_Int32_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Shell.%23ctor(System.String%2CSystem.String%2CSystem.String%2CSystem.String%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Shell.cs/#L113">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Shell.cs/#L113">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Shell__ctor_" data-uid="AutoCheck.Core.Connectors.Shell.#ctor*"></a>
   <h4 id="AutoCheck_Core_Connectors_Shell__ctor_System_String_System_String_System_String_System_String_System_Int32_" data-uid="AutoCheck.Core.Connectors.Shell.#ctor(System.String,System.String,System.String,System.String,System.Int32)">Shell(String, String, String, String, Int32)</h4>
@@ -426,7 +426,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Shell_Host.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Shell.Host%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Shell.cs/#L45">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Shell.cs/#L45">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Shell_Host_" data-uid="AutoCheck.Core.Connectors.Shell.Host*"></a>
   <h4 id="AutoCheck_Core_Connectors_Shell_Host" data-uid="AutoCheck.Core.Connectors.Shell.Host">Host</h4>
@@ -457,7 +457,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Shell_IsLocal.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Shell.IsLocal%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Shell.cs/#L69">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Shell.cs/#L69">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Shell_IsLocal_" data-uid="AutoCheck.Core.Connectors.Shell.IsLocal*"></a>
   <h4 id="AutoCheck_Core_Connectors_Shell_IsLocal" data-uid="AutoCheck.Core.Connectors.Shell.IsLocal">IsLocal</h4>
@@ -488,7 +488,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Shell_IsRemote.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Shell.IsRemote%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Shell.cs/#L79">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Shell.cs/#L79">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Shell_IsRemote_" data-uid="AutoCheck.Core.Connectors.Shell.IsRemote*"></a>
   <h4 id="AutoCheck_Core_Connectors_Shell_IsRemote" data-uid="AutoCheck.Core.Connectors.Shell.IsRemote">IsRemote</h4>
@@ -519,7 +519,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Shell_Password.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Shell.Password%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Shell.cs/#L57">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Shell.cs/#L57">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Shell_Password_" data-uid="AutoCheck.Core.Connectors.Shell.Password*"></a>
   <h4 id="AutoCheck_Core_Connectors_Shell_Password" data-uid="AutoCheck.Core.Connectors.Shell.Password">Password</h4>
@@ -550,7 +550,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Shell_Port.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Shell.Port%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Shell.cs/#L63">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Shell.cs/#L63">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Shell_Port_" data-uid="AutoCheck.Core.Connectors.Shell.Port*"></a>
   <h4 id="AutoCheck_Core_Connectors_Shell_Port" data-uid="AutoCheck.Core.Connectors.Shell.Port">Port</h4>
@@ -581,7 +581,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Shell_RemoteOS.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Shell.RemoteOS%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Shell.cs/#L39">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Shell.cs/#L39">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Shell_RemoteOS_" data-uid="AutoCheck.Core.Connectors.Shell.RemoteOS*"></a>
   <h4 id="AutoCheck_Core_Connectors_Shell_RemoteOS" data-uid="AutoCheck.Core.Connectors.Shell.RemoteOS">RemoteOS</h4>
@@ -612,7 +612,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Shell_Username.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Shell.Username%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Shell.cs/#L51">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Shell.cs/#L51">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Shell_Username_" data-uid="AutoCheck.Core.Connectors.Shell.Username*"></a>
   <h4 id="AutoCheck_Core_Connectors_Shell_Username" data-uid="AutoCheck.Core.Connectors.Shell.Username">Username</h4>
@@ -645,7 +645,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Shell_CountFiles_System_String_System_Boolean_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Shell.CountFiles(System.String%2CSystem.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Shell.cs/#L300">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Shell.cs/#L300">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Shell_CountFiles_" data-uid="AutoCheck.Core.Connectors.Shell.CountFiles*"></a>
   <h4 id="AutoCheck_Core_Connectors_Shell_CountFiles_System_String_System_Boolean_" data-uid="AutoCheck.Core.Connectors.Shell.CountFiles(System.String,System.Boolean)">CountFiles(String, Boolean)</h4>
@@ -701,7 +701,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Shell_CountFiles_System_String_System_String_System_Boolean_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Shell.CountFiles(System.String%2CSystem.String%2CSystem.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Shell.cs/#L290">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Shell.cs/#L290">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Shell_CountFiles_" data-uid="AutoCheck.Core.Connectors.Shell.CountFiles*"></a>
   <h4 id="AutoCheck_Core_Connectors_Shell_CountFiles_System_String_System_String_System_Boolean_" data-uid="AutoCheck.Core.Connectors.Shell.CountFiles(System.String,System.String,System.Boolean)">CountFiles(String, String, Boolean)</h4>
@@ -763,7 +763,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Shell_CountFolders_System_String_System_Boolean_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Shell.CountFolders(System.String%2CSystem.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Shell.cs/#L279">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Shell.cs/#L279">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Shell_CountFolders_" data-uid="AutoCheck.Core.Connectors.Shell.CountFolders*"></a>
   <h4 id="AutoCheck_Core_Connectors_Shell_CountFolders_System_String_System_Boolean_" data-uid="AutoCheck.Core.Connectors.Shell.CountFolders(System.String,System.Boolean)">CountFolders(String, Boolean)</h4>
@@ -819,7 +819,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Shell_CountFolders_System_String_System_String_System_Boolean_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Shell.CountFolders(System.String%2CSystem.String%2CSystem.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Shell.cs/#L269">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Shell.cs/#L269">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Shell_CountFolders_" data-uid="AutoCheck.Core.Connectors.Shell.CountFolders*"></a>
   <h4 id="AutoCheck_Core_Connectors_Shell_CountFolders_System_String_System_String_System_Boolean_" data-uid="AutoCheck.Core.Connectors.Shell.CountFolders(System.String,System.String,System.Boolean)">CountFolders(String, String, Boolean)</h4>
@@ -881,7 +881,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Shell_Dispose.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Shell.Dispose%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Shell.cs/#L141">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Shell.cs/#L141">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Shell_Dispose_" data-uid="AutoCheck.Core.Connectors.Shell.Dispose*"></a>
   <h4 id="AutoCheck_Core_Connectors_Shell_Dispose" data-uid="AutoCheck.Core.Connectors.Shell.Dispose">Dispose()</h4>
@@ -899,7 +899,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Shell_DownloadFile_System_String_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Shell.DownloadFile(System.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Shell.cs/#L360">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Shell.cs/#L360">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Shell_DownloadFile_" data-uid="AutoCheck.Core.Connectors.Shell.DownloadFile*"></a>
   <h4 id="AutoCheck_Core_Connectors_Shell_DownloadFile_System_String_System_String_" data-uid="AutoCheck.Core.Connectors.Shell.DownloadFile(System.String,System.String)">DownloadFile(String, String)</h4>
@@ -955,7 +955,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Shell_DownloadFolder_System_String_System_Boolean_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Shell.DownloadFolder(System.String%2CSystem.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Shell.cs/#L384">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Shell.cs/#L384">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Shell_DownloadFolder_" data-uid="AutoCheck.Core.Connectors.Shell.DownloadFolder*"></a>
   <h4 id="AutoCheck_Core_Connectors_Shell_DownloadFolder_System_String_System_Boolean_" data-uid="AutoCheck.Core.Connectors.Shell.DownloadFolder(System.String,System.Boolean)">DownloadFolder(String, Boolean)</h4>
@@ -1011,7 +1011,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Shell_DownloadFolder_System_String_System_String_System_Boolean_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Shell.DownloadFolder(System.String%2CSystem.String%2CSystem.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Shell.cs/#L395">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Shell.cs/#L395">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Shell_DownloadFolder_" data-uid="AutoCheck.Core.Connectors.Shell.DownloadFolder*"></a>
   <h4 id="AutoCheck_Core_Connectors_Shell_DownloadFolder_System_String_System_String_System_Boolean_" data-uid="AutoCheck.Core.Connectors.Shell.DownloadFolder(System.String,System.String,System.Boolean)">DownloadFolder(String, String, Boolean)</h4>
@@ -1073,7 +1073,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Shell_ExistsFile_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Shell.ExistsFile(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Shell.cs/#L333">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Shell.cs/#L333">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Shell_ExistsFile_" data-uid="AutoCheck.Core.Connectors.Shell.ExistsFile*"></a>
   <h4 id="AutoCheck_Core_Connectors_Shell_ExistsFile_System_String_" data-uid="AutoCheck.Core.Connectors.Shell.ExistsFile(System.String)">ExistsFile(String)</h4>
@@ -1122,7 +1122,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Shell_ExistsFile_System_String_System_String_System_Boolean_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Shell.ExistsFile(System.String%2CSystem.String%2CSystem.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Shell.cs/#L349">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Shell.cs/#L349">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Shell_ExistsFile_" data-uid="AutoCheck.Core.Connectors.Shell.ExistsFile*"></a>
   <h4 id="AutoCheck_Core_Connectors_Shell_ExistsFile_System_String_System_String_System_Boolean_" data-uid="AutoCheck.Core.Connectors.Shell.ExistsFile(System.String,System.String,System.Boolean)">ExistsFile(String, String, Boolean)</h4>
@@ -1184,7 +1184,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Shell_ExistsFolder_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Shell.ExistsFolder(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Shell.cs/#L308">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Shell.cs/#L308">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Shell_ExistsFolder_" data-uid="AutoCheck.Core.Connectors.Shell.ExistsFolder*"></a>
   <h4 id="AutoCheck_Core_Connectors_Shell_ExistsFolder_System_String_" data-uid="AutoCheck.Core.Connectors.Shell.ExistsFolder(System.String)">ExistsFolder(String)</h4>
@@ -1233,7 +1233,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Shell_ExistsFolder_System_String_System_String_System_Boolean_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Shell.ExistsFolder(System.String%2CSystem.String%2CSystem.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Shell.cs/#L324">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Shell.cs/#L324">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Shell_ExistsFolder_" data-uid="AutoCheck.Core.Connectors.Shell.ExistsFolder*"></a>
   <h4 id="AutoCheck_Core_Connectors_Shell_ExistsFolder_System_String_System_String_System_Boolean_" data-uid="AutoCheck.Core.Connectors.Shell.ExistsFolder(System.String,System.String,System.Boolean)">ExistsFolder(String, String, Boolean)</h4>
@@ -1295,7 +1295,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Shell_GetFile_System_String_System_String_System_Boolean_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Shell.GetFile(System.String%2CSystem.String%2CSystem.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Shell.cs/#L200">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Shell.cs/#L200">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Shell_GetFile_" data-uid="AutoCheck.Core.Connectors.Shell.GetFile*"></a>
   <h4 id="AutoCheck_Core_Connectors_Shell_GetFile_System_String_System_String_System_Boolean_" data-uid="AutoCheck.Core.Connectors.Shell.GetFile(System.String,System.String,System.Boolean)">GetFile(String, String, Boolean)</h4>
@@ -1357,7 +1357,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Shell_GetFiles_System_String_System_Boolean_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Shell.GetFiles(System.String%2CSystem.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Shell.cs/#L240">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Shell.cs/#L240">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Shell_GetFiles_" data-uid="AutoCheck.Core.Connectors.Shell.GetFiles*"></a>
   <h4 id="AutoCheck_Core_Connectors_Shell_GetFiles_System_String_System_Boolean_" data-uid="AutoCheck.Core.Connectors.Shell.GetFiles(System.String,System.Boolean)">GetFiles(String, Boolean)</h4>
@@ -1413,7 +1413,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Shell_GetFiles_System_String_System_String_System_Boolean_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Shell.GetFiles(System.String%2CSystem.String%2CSystem.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Shell.cs/#L251">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Shell.cs/#L251">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Shell_GetFiles_" data-uid="AutoCheck.Core.Connectors.Shell.GetFiles*"></a>
   <h4 id="AutoCheck_Core_Connectors_Shell_GetFiles_System_String_System_String_System_Boolean_" data-uid="AutoCheck.Core.Connectors.Shell.GetFiles(System.String,System.String,System.Boolean)">GetFiles(String, String, Boolean)</h4>
@@ -1475,7 +1475,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Shell_GetFolder_System_String_System_String_System_Boolean_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Shell.GetFolder(System.String%2CSystem.String%2CSystem.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Shell.cs/#L187">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Shell.cs/#L187">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Shell_GetFolder_" data-uid="AutoCheck.Core.Connectors.Shell.GetFolder*"></a>
   <h4 id="AutoCheck_Core_Connectors_Shell_GetFolder_System_String_System_String_System_Boolean_" data-uid="AutoCheck.Core.Connectors.Shell.GetFolder(System.String,System.String,System.Boolean)">GetFolder(String, String, Boolean)</h4>
@@ -1537,7 +1537,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Shell_GetFolders_System_String_System_Boolean_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Shell.GetFolders(System.String%2CSystem.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Shell.cs/#L212">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Shell.cs/#L212">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Shell_GetFolders_" data-uid="AutoCheck.Core.Connectors.Shell.GetFolders*"></a>
   <h4 id="AutoCheck_Core_Connectors_Shell_GetFolders_System_String_System_Boolean_" data-uid="AutoCheck.Core.Connectors.Shell.GetFolders(System.String,System.Boolean)">GetFolders(String, Boolean)</h4>
@@ -1593,7 +1593,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Shell_GetFolders_System_String_System_String_System_Boolean_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Shell.GetFolders(System.String%2CSystem.String%2CSystem.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Shell.cs/#L223">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Shell.cs/#L223">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Shell_GetFolders_" data-uid="AutoCheck.Core.Connectors.Shell.GetFolders*"></a>
   <h4 id="AutoCheck_Core_Connectors_Shell_GetFolders_System_String_System_String_System_Boolean_" data-uid="AutoCheck.Core.Connectors.Shell.GetFolders(System.String,System.String,System.Boolean)">GetFolders(String, String, Boolean)</h4>
@@ -1655,7 +1655,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Shell_RunCommand_System_String_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Shell.RunCommand(System.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Shell.cs/#L165">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Shell.cs/#L165">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Shell_RunCommand_" data-uid="AutoCheck.Core.Connectors.Shell.RunCommand*"></a>
   <h4 id="AutoCheck_Core_Connectors_Shell_RunCommand_System_String_System_String_" data-uid="AutoCheck.Core.Connectors.Shell.RunCommand(System.String,System.String)">RunCommand(String, String)</h4>
@@ -1710,7 +1710,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Shell_TestConnection.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Shell.TestConnection%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Shell.cs/#L148">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Shell.cs/#L148">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Shell_TestConnection_" data-uid="AutoCheck.Core.Connectors.Shell.TestConnection*"></a>
   <h4 id="AutoCheck_Core_Connectors_Shell_TestConnection" data-uid="AutoCheck.Core.Connectors.Shell.TestConnection">TestConnection()</h4>
@@ -1736,7 +1736,7 @@
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Shell.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Shell%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Shell.cs/#L33" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Shell.cs/#L33" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.Connectors.Xml.XmlNodeType.html
+++ b/docs/html/api/AutoCheck.Core.Connectors.Xml.XmlNodeType.html
@@ -327,7 +327,7 @@
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Xml_XmlNodeType.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Xml.XmlNodeType%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Xml.cs/#L36" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Xml.cs/#L36" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.Connectors.Xml.html
+++ b/docs/html/api/AutoCheck.Core.Connectors.Xml.html
@@ -305,7 +305,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Xml__ctor_AutoCheck_Core_Utils_OS_System_String_System_String_System_String_System_Int32_System_String_ValidationType_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Xml.%23ctor(AutoCheck.Core.Utils.OS%2CSystem.String%2CSystem.String%2CSystem.String%2CSystem.Int32%2CSystem.String%2CValidationType)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Xml.cs/#L78">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Xml.cs/#L78">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Xml__ctor_" data-uid="AutoCheck.Core.Connectors.Xml.#ctor*"></a>
   <h4 id="AutoCheck_Core_Connectors_Xml__ctor_AutoCheck_Core_Utils_OS_System_String_System_String_System_String_System_Int32_System_String_ValidationType_" data-uid="AutoCheck.Core.Connectors.Xml.#ctor(AutoCheck.Core.Utils.OS,System.String,System.String,System.String,System.Int32,System.String,ValidationType)">Xml(Utils.OS, String, String, String, Int32, String, ValidationType)</h4>
@@ -367,7 +367,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Xml__ctor_AutoCheck_Core_Utils_OS_System_String_System_String_System_String_System_String_ValidationType_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Xml.%23ctor(AutoCheck.Core.Utils.OS%2CSystem.String%2CSystem.String%2CSystem.String%2CSystem.String%2CValidationType)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Xml.cs/#L93">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Xml.cs/#L93">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Xml__ctor_" data-uid="AutoCheck.Core.Connectors.Xml.#ctor*"></a>
   <h4 id="AutoCheck_Core_Connectors_Xml__ctor_AutoCheck_Core_Utils_OS_System_String_System_String_System_String_System_String_ValidationType_" data-uid="AutoCheck.Core.Connectors.Xml.#ctor(AutoCheck.Core.Utils.OS,System.String,System.String,System.String,System.String,ValidationType)">Xml(Utils.OS, String, String, String, String, ValidationType)</h4>
@@ -424,7 +424,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Xml__ctor_System_String_ValidationType_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Xml.%23ctor(System.String%2CValidationType)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Xml.cs/#L64">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Xml.cs/#L64">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Xml__ctor_" data-uid="AutoCheck.Core.Connectors.Xml.#ctor*"></a>
   <h4 id="AutoCheck_Core_Connectors_Xml__ctor_System_String_ValidationType_" data-uid="AutoCheck.Core.Connectors.Xml.#ctor(System.String,ValidationType)">Xml(String, ValidationType)</h4>
@@ -466,7 +466,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Xml_Comments.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Xml.Comments%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Xml.cs/#L45">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Xml.cs/#L45">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Xml_Comments_" data-uid="AutoCheck.Core.Connectors.Xml.Comments*"></a>
   <h4 id="AutoCheck_Core_Connectors_Xml_Comments" data-uid="AutoCheck.Core.Connectors.Xml.Comments">Comments</h4>
@@ -496,7 +496,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Xml_Raw.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Xml.Raw%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Xml.cs/#L57">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Xml.cs/#L57">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Xml_Raw_" data-uid="AutoCheck.Core.Connectors.Xml.Raw*"></a>
   <h4 id="AutoCheck_Core_Connectors_Xml_Raw" data-uid="AutoCheck.Core.Connectors.Xml.Raw">Raw</h4>
@@ -527,7 +527,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Xml_XmlDoc.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Xml.XmlDoc%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Xml.cs/#L51">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Xml.cs/#L51">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Xml_XmlDoc_" data-uid="AutoCheck.Core.Connectors.Xml.XmlDoc*"></a>
   <h4 id="AutoCheck_Core_Connectors_Xml_XmlDoc" data-uid="AutoCheck.Core.Connectors.Xml.XmlDoc">XmlDoc</h4>
@@ -560,7 +560,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Xml_CountNodes_System_String_AutoCheck_Core_Connectors_Xml_XmlNodeType_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Xml.CountNodes(System.String%2CAutoCheck.Core.Connectors.Xml.XmlNodeType)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Xml.cs/#L175">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Xml.cs/#L175">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Xml_CountNodes_" data-uid="AutoCheck.Core.Connectors.Xml.CountNodes*"></a>
   <h4 id="AutoCheck_Core_Connectors_Xml_CountNodes_System_String_AutoCheck_Core_Connectors_Xml_XmlNodeType_" data-uid="AutoCheck.Core.Connectors.Xml.CountNodes(System.String,AutoCheck.Core.Connectors.Xml.XmlNodeType)">CountNodes(String, Xml.XmlNodeType)</h4>
@@ -615,7 +615,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Xml_CountNodes_XmlNode_System_String_AutoCheck_Core_Connectors_Xml_XmlNodeType_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Xml.CountNodes(XmlNode%2CSystem.String%2CAutoCheck.Core.Connectors.Xml.XmlNodeType)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Xml.cs/#L185">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Xml.cs/#L185">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Xml_CountNodes_" data-uid="AutoCheck.Core.Connectors.Xml.CountNodes*"></a>
   <h4 id="AutoCheck_Core_Connectors_Xml_CountNodes_XmlNode_System_String_AutoCheck_Core_Connectors_Xml_XmlNodeType_" data-uid="AutoCheck.Core.Connectors.Xml.CountNodes(XmlNode,System.String,AutoCheck.Core.Connectors.Xml.XmlNodeType)">CountNodes(XmlNode, String, Xml.XmlNodeType)</h4>
@@ -676,7 +676,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Xml_Dispose.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Xml.Dispose%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Xml.cs/#L100">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Xml.cs/#L100">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Xml_Dispose_" data-uid="AutoCheck.Core.Connectors.Xml.Dispose*"></a>
   <h4 id="AutoCheck_Core_Connectors_Xml_Dispose" data-uid="AutoCheck.Core.Connectors.Xml.Dispose">Dispose()</h4>
@@ -694,7 +694,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Xml_Equals_AutoCheck_Core_Connectors_Xml_System_Boolean_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Xml.Equals(AutoCheck.Core.Connectors.Xml%2CSystem.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Xml.cs/#L203">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Xml.cs/#L203">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Xml_Equals_" data-uid="AutoCheck.Core.Connectors.Xml.Equals*"></a>
   <h4 id="AutoCheck_Core_Connectors_Xml_Equals_AutoCheck_Core_Connectors_Xml_System_Boolean_" data-uid="AutoCheck.Core.Connectors.Xml.Equals(AutoCheck.Core.Connectors.Xml,System.Boolean)">Equals(Xml, Boolean)</h4>
@@ -746,7 +746,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Xml_Equals_XmlDocument_System_Boolean_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Xml.Equals(XmlDocument%2CSystem.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Xml.cs/#L194">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Xml.cs/#L194">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Xml_Equals_" data-uid="AutoCheck.Core.Connectors.Xml.Equals*"></a>
   <h4 id="AutoCheck_Core_Connectors_Xml_Equals_XmlDocument_System_Boolean_" data-uid="AutoCheck.Core.Connectors.Xml.Equals(XmlDocument,System.Boolean)">Equals(XmlDocument, Boolean)</h4>
@@ -798,7 +798,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Xml_SelectNodes_System_String_AutoCheck_Core_Connectors_Xml_XmlNodeType_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Xml.SelectNodes(System.String%2CAutoCheck.Core.Connectors.Xml.XmlNodeType)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Xml.cs/#L108">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Xml.cs/#L108">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Xml_SelectNodes_" data-uid="AutoCheck.Core.Connectors.Xml.SelectNodes*"></a>
   <h4 id="AutoCheck_Core_Connectors_Xml_SelectNodes_System_String_AutoCheck_Core_Connectors_Xml_XmlNodeType_" data-uid="AutoCheck.Core.Connectors.Xml.SelectNodes(System.String,AutoCheck.Core.Connectors.Xml.XmlNodeType)">SelectNodes(String, Xml.XmlNodeType)</h4>
@@ -853,7 +853,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Xml_SelectNodes_XmlNode_System_String_AutoCheck_Core_Connectors_Xml_XmlNodeType_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Xml.SelectNodes(XmlNode%2CSystem.String%2CAutoCheck.Core.Connectors.Xml.XmlNodeType)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Xml.cs/#L118">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Xml.cs/#L118">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Xml_SelectNodes_" data-uid="AutoCheck.Core.Connectors.Xml.SelectNodes*"></a>
   <h4 id="AutoCheck_Core_Connectors_Xml_SelectNodes_XmlNode_System_String_AutoCheck_Core_Connectors_Xml_XmlNodeType_" data-uid="AutoCheck.Core.Connectors.Xml.SelectNodes(XmlNode,System.String,AutoCheck.Core.Connectors.Xml.XmlNodeType)">SelectNodes(XmlNode, String, Xml.XmlNodeType)</h4>
@@ -924,7 +924,7 @@
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Xml.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Xml%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Xml.cs/#L35" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Xml.cs/#L35" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.Connectors.Zip.html
+++ b/docs/html/api/AutoCheck.Core.Connectors.Zip.html
@@ -303,7 +303,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Zip__ctor_AutoCheck_Core_Utils_OS_System_String_System_String_System_String_System_Int32_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Zip.%23ctor(AutoCheck.Core.Utils.OS%2CSystem.String%2CSystem.String%2CSystem.String%2CSystem.Int32%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Zip.cs/#L63">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Zip.cs/#L63">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Zip__ctor_" data-uid="AutoCheck.Core.Connectors.Zip.#ctor*"></a>
   <h4 id="AutoCheck_Core_Connectors_Zip__ctor_AutoCheck_Core_Utils_OS_System_String_System_String_System_String_System_Int32_System_String_" data-uid="AutoCheck.Core.Connectors.Zip.#ctor(AutoCheck.Core.Utils.OS,System.String,System.String,System.String,System.Int32,System.String)">Zip(Utils.OS, String, String, String, Int32, String)</h4>
@@ -360,7 +360,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Zip__ctor_AutoCheck_Core_Utils_OS_System_String_System_String_System_String_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Zip.%23ctor(AutoCheck.Core.Utils.OS%2CSystem.String%2CSystem.String%2CSystem.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Zip.cs/#L50">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Zip.cs/#L50">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Zip__ctor_" data-uid="AutoCheck.Core.Connectors.Zip.#ctor*"></a>
   <h4 id="AutoCheck_Core_Connectors_Zip__ctor_AutoCheck_Core_Utils_OS_System_String_System_String_System_String_System_String_" data-uid="AutoCheck.Core.Connectors.Zip.#ctor(AutoCheck.Core.Utils.OS,System.String,System.String,System.String,System.String)">Zip(Utils.OS, String, String, String, String)</h4>
@@ -412,7 +412,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Zip__ctor_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Zip.%23ctor(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Zip.cs/#L37">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Zip.cs/#L37">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Zip__ctor_" data-uid="AutoCheck.Core.Connectors.Zip.#ctor*"></a>
   <h4 id="AutoCheck_Core_Connectors_Zip__ctor_System_String_" data-uid="AutoCheck.Core.Connectors.Zip.#ctor(System.String)">Zip(String)</h4>
@@ -448,7 +448,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Zip_ZipFile.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Zip.ZipFile%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Zip.cs/#L30">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Zip.cs/#L30">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Zip_ZipFile_" data-uid="AutoCheck.Core.Connectors.Zip.ZipFile*"></a>
   <h4 id="AutoCheck_Core_Connectors_Zip_ZipFile" data-uid="AutoCheck.Core.Connectors.Zip.ZipFile">ZipFile</h4>
@@ -480,7 +480,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Zip_Dispose.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Zip.Dispose%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Zip.cs/#L87">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Zip.cs/#L87">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Zip_Dispose_" data-uid="AutoCheck.Core.Connectors.Zip.Dispose*"></a>
   <h4 id="AutoCheck_Core_Connectors_Zip_Dispose" data-uid="AutoCheck.Core.Connectors.Zip.Dispose">Dispose()</h4>
@@ -498,7 +498,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Zip_Extract_System_Boolean_System_String_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Zip.Extract(System.Boolean%2CSystem.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Zip.cs/#L106">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Zip.cs/#L106">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Zip_Extract_" data-uid="AutoCheck.Core.Connectors.Zip.Extract*"></a>
   <h4 id="AutoCheck_Core_Connectors_Zip_Extract_System_Boolean_System_String_System_String_" data-uid="AutoCheck.Core.Connectors.Zip.Extract(System.Boolean,System.String,System.String)">Extract(Boolean, String, String)</h4>
@@ -544,7 +544,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Zip_Extract_System_String_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Zip.Extract(System.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Zip.cs/#L96">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Zip.cs/#L96">View Source</a>
   </span>
   <a id="AutoCheck_Core_Connectors_Zip_Extract_" data-uid="AutoCheck.Core.Connectors.Zip.Extract*"></a>
   <h4 id="AutoCheck_Core_Connectors_Zip_Extract_System_String_System_String_" data-uid="AutoCheck.Core.Connectors.Zip.Extract(System.String,System.String)">Extract(String, String)</h4>
@@ -594,7 +594,7 @@
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Connectors_Zip.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Connectors.Zip%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/connectors/Zip.cs/#L29" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/connectors/Zip.cs/#L29" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.CopyDetectors.Base.html
+++ b/docs/html/api/AutoCheck.Core.CopyDetectors.Base.html
@@ -299,7 +299,7 @@ This class is in charge of performing the copy detection along the student's fil
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_CopyDetectors_Base__ctor_System_Single_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.CopyDetectors.Base.%23ctor(System.Single%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/copy/Base.cs/#L55">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/copy/Base.cs/#L55">View Source</a>
   </span>
   <a id="AutoCheck_Core_CopyDetectors_Base__ctor_" data-uid="AutoCheck.Core.CopyDetectors.Base.#ctor*"></a>
   <h4 id="AutoCheck_Core_CopyDetectors_Base__ctor_System_Single_System_String_" data-uid="AutoCheck.Core.CopyDetectors.Base.#ctor(System.Single,System.String)">Base(Single, String)</h4>
@@ -339,7 +339,7 @@ This class is in charge of performing the copy detection along the student's fil
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_CopyDetectors_Base_Count.md&amp;value=---%0Auid%3A%20AutoCheck.Core.CopyDetectors.Base.Count%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/copy/Base.cs/#L50">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/copy/Base.cs/#L50">View Source</a>
   </span>
   <a id="AutoCheck_Core_CopyDetectors_Base_Count_" data-uid="AutoCheck.Core.CopyDetectors.Base.Count*"></a>
   <h4 id="AutoCheck_Core_CopyDetectors_Base_Count" data-uid="AutoCheck.Core.CopyDetectors.Base.Count">Count</h4>
@@ -370,7 +370,7 @@ This class is in charge of performing the copy detection along the student's fil
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_CopyDetectors_Base_FilePattern.md&amp;value=---%0Auid%3A%20AutoCheck.Core.CopyDetectors.Base.FilePattern%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/copy/Base.cs/#L44">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/copy/Base.cs/#L44">View Source</a>
   </span>
   <a id="AutoCheck_Core_CopyDetectors_Base_FilePattern_" data-uid="AutoCheck.Core.CopyDetectors.Base.FilePattern*"></a>
   <h4 id="AutoCheck_Core_CopyDetectors_Base_FilePattern" data-uid="AutoCheck.Core.CopyDetectors.Base.FilePattern">FilePattern</h4>
@@ -401,7 +401,7 @@ This class is in charge of performing the copy detection along the student's fil
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_CopyDetectors_Base_Threshold.md&amp;value=---%0Auid%3A%20AutoCheck.Core.CopyDetectors.Base.Threshold%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/copy/Base.cs/#L38">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/copy/Base.cs/#L38">View Source</a>
   </span>
   <a id="AutoCheck_Core_CopyDetectors_Base_Threshold_" data-uid="AutoCheck.Core.CopyDetectors.Base.Threshold*"></a>
   <h4 id="AutoCheck_Core_CopyDetectors_Base_Threshold" data-uid="AutoCheck.Core.CopyDetectors.Base.Threshold">Threshold</h4>
@@ -434,7 +434,7 @@ This class is in charge of performing the copy detection along the student's fil
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_CopyDetectors_Base_Compare.md&amp;value=---%0Auid%3A%20AutoCheck.Core.CopyDetectors.Base.Compare%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/copy/Base.cs/#L138">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/copy/Base.cs/#L138">View Source</a>
   </span>
   <a id="AutoCheck_Core_CopyDetectors_Base_Compare_" data-uid="AutoCheck.Core.CopyDetectors.Base.Compare*"></a>
   <h4 id="AutoCheck_Core_CopyDetectors_Base_Compare" data-uid="AutoCheck.Core.CopyDetectors.Base.Compare">Compare()</h4>
@@ -450,7 +450,7 @@ This class is in charge of performing the copy detection along the student's fil
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_CopyDetectors_Base_CopyDetected_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.CopyDetectors.Base.CopyDetected(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/copy/Base.cs/#L147">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/copy/Base.cs/#L147">View Source</a>
   </span>
   <a id="AutoCheck_Core_CopyDetectors_Base_CopyDetected_" data-uid="AutoCheck.Core.CopyDetectors.Base.CopyDetected*"></a>
   <h4 id="AutoCheck_Core_CopyDetectors_Base_CopyDetected_System_String_" data-uid="AutoCheck.Core.CopyDetectors.Base.CopyDetected(System.String)">CopyDetected(String)</h4>
@@ -501,7 +501,7 @@ The Compare() method should be called firts.</p>
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_CopyDetectors_Base_Dispose.md&amp;value=---%0Auid%3A%20AutoCheck.Core.CopyDetectors.Base.Dispose%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/copy/Base.cs/#L67">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/copy/Base.cs/#L67">View Source</a>
   </span>
   <a id="AutoCheck_Core_CopyDetectors_Base_Dispose_" data-uid="AutoCheck.Core.CopyDetectors.Base.Dispose*"></a>
   <h4 id="AutoCheck_Core_CopyDetectors_Base_Dispose" data-uid="AutoCheck.Core.CopyDetectors.Base.Dispose">Dispose()</h4>
@@ -517,7 +517,7 @@ The Compare() method should be called firts.</p>
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_CopyDetectors_Base_GetDetails_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.CopyDetectors.Base.GetDetails(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/copy/Base.cs/#L154">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/copy/Base.cs/#L154">View Source</a>
   </span>
   <a id="AutoCheck_Core_CopyDetectors_Base_GetDetails_" data-uid="AutoCheck.Core.CopyDetectors.Base.GetDetails*"></a>
   <h4 id="AutoCheck_Core_CopyDetectors_Base_GetDetails_System_String_" data-uid="AutoCheck.Core.CopyDetectors.Base.GetDetails(System.String)">GetDetails(String)</h4>
@@ -567,7 +567,7 @@ The Compare() method should be called firts.</p>
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_CopyDetectors_Base_Load_AutoCheck_Core_Utils_OS_System_String_System_String_System_String_System_Int32_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.CopyDetectors.Base.Load(AutoCheck.Core.Utils.OS%2CSystem.String%2CSystem.String%2CSystem.String%2CSystem.Int32%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/copy/Base.cs/#L106">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/copy/Base.cs/#L106">View Source</a>
   </span>
   <a id="AutoCheck_Core_CopyDetectors_Base_Load_" data-uid="AutoCheck.Core.CopyDetectors.Base.Load*"></a>
   <h4 id="AutoCheck_Core_CopyDetectors_Base_Load_AutoCheck_Core_Utils_OS_System_String_System_String_System_String_System_Int32_System_String_" data-uid="AutoCheck.Core.CopyDetectors.Base.Load(AutoCheck.Core.Utils.OS,System.String,System.String,System.String,System.Int32,System.String)">Load(Utils.OS, String, String, String, Int32, String)</h4>
@@ -629,7 +629,7 @@ The Compare() method should be called firts.</p>
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_CopyDetectors_Base_Load_AutoCheck_Core_Utils_OS_System_String_System_String_System_String_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.CopyDetectors.Base.Load(AutoCheck.Core.Utils.OS%2CSystem.String%2CSystem.String%2CSystem.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/copy/Base.cs/#L92">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/copy/Base.cs/#L92">View Source</a>
   </span>
   <a id="AutoCheck_Core_CopyDetectors_Base_Load_" data-uid="AutoCheck.Core.CopyDetectors.Base.Load*"></a>
   <h4 id="AutoCheck_Core_CopyDetectors_Base_Load_AutoCheck_Core_Utils_OS_System_String_System_String_System_String_System_String_" data-uid="AutoCheck.Core.CopyDetectors.Base.Load(AutoCheck.Core.Utils.OS,System.String,System.String,System.String,System.String)">Load(Utils.OS, String, String, String, String)</h4>
@@ -685,7 +685,7 @@ The Compare() method should be called firts.</p>
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_CopyDetectors_Base_Load_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.CopyDetectors.Base.Load(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/copy/Base.cs/#L73">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/copy/Base.cs/#L73">View Source</a>
   </span>
   <a id="AutoCheck_Core_CopyDetectors_Base_Load_" data-uid="AutoCheck.Core.CopyDetectors.Base.Load*"></a>
   <h4 id="AutoCheck_Core_CopyDetectors_Base_Load_System_String_" data-uid="AutoCheck.Core.CopyDetectors.Base.Load(System.String)">Load(String)</h4>
@@ -719,7 +719,7 @@ The Compare() method should be called firts.</p>
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_CopyDetectors_Base_Load_System_String_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.CopyDetectors.Base.Load(System.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/copy/Base.cs/#L133">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/copy/Base.cs/#L133">View Source</a>
   </span>
   <a id="AutoCheck_Core_CopyDetectors_Base_Load_" data-uid="AutoCheck.Core.CopyDetectors.Base.Load*"></a>
   <h4 id="AutoCheck_Core_CopyDetectors_Base_Load_System_String_System_String_" data-uid="AutoCheck.Core.CopyDetectors.Base.Load(System.String,System.String)">Load(String, String)</h4>
@@ -769,7 +769,7 @@ The Compare() method should be called firts.</p>
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_CopyDetectors_Base.md&amp;value=---%0Auid%3A%20AutoCheck.Core.CopyDetectors.Base%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/copy/Base.cs/#L33" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/copy/Base.cs/#L33" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.CopyDetectors.Css.html
+++ b/docs/html/api/AutoCheck.Core.CopyDetectors.Css.html
@@ -344,7 +344,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_CopyDetectors_Css__ctor_System_Single_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.CopyDetectors.Css.%23ctor(System.Single%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/copy/Css.cs/#L29">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/copy/Css.cs/#L29">View Source</a>
   </span>
   <a id="AutoCheck_Core_CopyDetectors_Css__ctor_" data-uid="AutoCheck.Core.CopyDetectors.Css.#ctor*"></a>
   <h4 id="AutoCheck_Core_CopyDetectors_Css__ctor_System_Single_System_String_" data-uid="AutoCheck.Core.CopyDetectors.Css.#ctor(System.Single,System.String)">Css(Single, String)</h4>
@@ -392,7 +392,7 @@
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_CopyDetectors_Css.md&amp;value=---%0Auid%3A%20AutoCheck.Core.CopyDetectors.Css%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/copy/Css.cs/#L25" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/copy/Css.cs/#L25" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.CopyDetectors.Html.html
+++ b/docs/html/api/AutoCheck.Core.CopyDetectors.Html.html
@@ -344,7 +344,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_CopyDetectors_Html__ctor_System_Single_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.CopyDetectors.Html.%23ctor(System.Single%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/copy/Html.cs/#L29">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/copy/Html.cs/#L29">View Source</a>
   </span>
   <a id="AutoCheck_Core_CopyDetectors_Html__ctor_" data-uid="AutoCheck.Core.CopyDetectors.Html.#ctor*"></a>
   <h4 id="AutoCheck_Core_CopyDetectors_Html__ctor_System_Single_System_String_" data-uid="AutoCheck.Core.CopyDetectors.Html.#ctor(System.Single,System.String)">Html(Single, String)</h4>
@@ -392,7 +392,7 @@
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_CopyDetectors_Html.md&amp;value=---%0Auid%3A%20AutoCheck.Core.CopyDetectors.Html%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/copy/Html.cs/#L25" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/copy/Html.cs/#L25" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.CopyDetectors.PlainText.html
+++ b/docs/html/api/AutoCheck.Core.CopyDetectors.PlainText.html
@@ -320,7 +320,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_CopyDetectors_PlainText__ctor_System_Single_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.CopyDetectors.PlainText.%23ctor(System.Single%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/copy/PlainText.cs/#L93">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/copy/PlainText.cs/#L93">View Source</a>
   </span>
   <a id="AutoCheck_Core_CopyDetectors_PlainText__ctor_" data-uid="AutoCheck.Core.CopyDetectors.PlainText.#ctor*"></a>
   <h4 id="AutoCheck_Core_CopyDetectors_PlainText__ctor_System_Single_System_String_" data-uid="AutoCheck.Core.CopyDetectors.PlainText.#ctor(System.Single,System.String)">PlainText(Single, String)</h4>
@@ -360,7 +360,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_CopyDetectors_PlainText_Count.md&amp;value=---%0Auid%3A%20AutoCheck.Core.CopyDetectors.PlainText.Count%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/copy/PlainText.cs/#L84">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/copy/PlainText.cs/#L84">View Source</a>
   </span>
   <a id="AutoCheck_Core_CopyDetectors_PlainText_Count_" data-uid="AutoCheck.Core.CopyDetectors.PlainText.Count*"></a>
   <h4 id="AutoCheck_Core_CopyDetectors_PlainText_Count" data-uid="AutoCheck.Core.CopyDetectors.PlainText.Count">Count</h4>
@@ -393,7 +393,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_CopyDetectors_PlainText_LineCountWeight.md&amp;value=---%0Auid%3A%20AutoCheck.Core.CopyDetectors.PlainText.LineCountWeight%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/copy/PlainText.cs/#L78">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/copy/PlainText.cs/#L78">View Source</a>
   </span>
   <a id="AutoCheck_Core_CopyDetectors_PlainText_LineCountWeight_" data-uid="AutoCheck.Core.CopyDetectors.PlainText.LineCountWeight*"></a>
   <h4 id="AutoCheck_Core_CopyDetectors_PlainText_LineCountWeight" data-uid="AutoCheck.Core.CopyDetectors.PlainText.LineCountWeight">LineCountWeight</h4>
@@ -424,7 +424,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_CopyDetectors_PlainText_WordCountWeight.md&amp;value=---%0Auid%3A%20AutoCheck.Core.CopyDetectors.PlainText.WordCountWeight%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/copy/PlainText.cs/#L72">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/copy/PlainText.cs/#L72">View Source</a>
   </span>
   <a id="AutoCheck_Core_CopyDetectors_PlainText_WordCountWeight_" data-uid="AutoCheck.Core.CopyDetectors.PlainText.WordCountWeight*"></a>
   <h4 id="AutoCheck_Core_CopyDetectors_PlainText_WordCountWeight" data-uid="AutoCheck.Core.CopyDetectors.PlainText.WordCountWeight">WordCountWeight</h4>
@@ -455,7 +455,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_CopyDetectors_PlainText_WordsAmountWeight.md&amp;value=---%0Auid%3A%20AutoCheck.Core.CopyDetectors.PlainText.WordsAmountWeight%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/copy/PlainText.cs/#L66">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/copy/PlainText.cs/#L66">View Source</a>
   </span>
   <a id="AutoCheck_Core_CopyDetectors_PlainText_WordsAmountWeight_" data-uid="AutoCheck.Core.CopyDetectors.PlainText.WordsAmountWeight*"></a>
   <h4 id="AutoCheck_Core_CopyDetectors_PlainText_WordsAmountWeight" data-uid="AutoCheck.Core.CopyDetectors.PlainText.WordsAmountWeight">WordsAmountWeight</h4>
@@ -488,7 +488,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_CopyDetectors_PlainText_Compare.md&amp;value=---%0Auid%3A%20AutoCheck.Core.CopyDetectors.PlainText.Compare%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/copy/PlainText.cs/#L128">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/copy/PlainText.cs/#L128">View Source</a>
   </span>
   <a id="AutoCheck_Core_CopyDetectors_PlainText_Compare_" data-uid="AutoCheck.Core.CopyDetectors.PlainText.Compare*"></a>
   <h4 id="AutoCheck_Core_CopyDetectors_PlainText_Compare" data-uid="AutoCheck.Core.CopyDetectors.PlainText.Compare">Compare()</h4>
@@ -506,7 +506,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_CopyDetectors_PlainText_CopyDetected_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.CopyDetectors.PlainText.CopyDetected(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/copy/PlainText.cs/#L163">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/copy/PlainText.cs/#L163">View Source</a>
   </span>
   <a id="AutoCheck_Core_CopyDetectors_PlainText_CopyDetected_" data-uid="AutoCheck.Core.CopyDetectors.PlainText.CopyDetected*"></a>
   <h4 id="AutoCheck_Core_CopyDetectors_PlainText_CopyDetected_System_String_" data-uid="AutoCheck.Core.CopyDetectors.PlainText.CopyDetected(System.String)">CopyDetected(String)</h4>
@@ -558,7 +558,7 @@ The Compare() method should be called firts.</p>
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_CopyDetectors_PlainText_Dispose.md&amp;value=---%0Auid%3A%20AutoCheck.Core.CopyDetectors.PlainText.Dispose%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/copy/PlainText.cs/#L106">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/copy/PlainText.cs/#L106">View Source</a>
   </span>
   <a id="AutoCheck_Core_CopyDetectors_PlainText_Dispose_" data-uid="AutoCheck.Core.CopyDetectors.PlainText.Dispose*"></a>
   <h4 id="AutoCheck_Core_CopyDetectors_PlainText_Dispose" data-uid="AutoCheck.Core.CopyDetectors.PlainText.Dispose">Dispose()</h4>
@@ -576,7 +576,7 @@ The Compare() method should be called firts.</p>
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_CopyDetectors_PlainText_GetDetails_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.CopyDetectors.PlainText.GetDetails(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/copy/PlainText.cs/#L182">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/copy/PlainText.cs/#L182">View Source</a>
   </span>
   <a id="AutoCheck_Core_CopyDetectors_PlainText_GetDetails_" data-uid="AutoCheck.Core.CopyDetectors.PlainText.GetDetails*"></a>
   <h4 id="AutoCheck_Core_CopyDetectors_PlainText_GetDetails_System_String_" data-uid="AutoCheck.Core.CopyDetectors.PlainText.GetDetails(System.String)">GetDetails(String)</h4>
@@ -628,7 +628,7 @@ The Compare() method should be called firts.</p>
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_CopyDetectors_PlainText_Load_System_String_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.CopyDetectors.PlainText.Load(System.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/copy/PlainText.cs/#L116">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/copy/PlainText.cs/#L116">View Source</a>
   </span>
   <a id="AutoCheck_Core_CopyDetectors_PlainText_Load_" data-uid="AutoCheck.Core.CopyDetectors.PlainText.Load*"></a>
   <h4 id="AutoCheck_Core_CopyDetectors_PlainText_Load_System_String_System_String_" data-uid="AutoCheck.Core.CopyDetectors.PlainText.Load(System.String,System.String)">Load(String, String)</h4>
@@ -680,7 +680,7 @@ The Compare() method should be called firts.</p>
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_CopyDetectors_PlainText.md&amp;value=---%0Auid%3A%20AutoCheck.Core.CopyDetectors.PlainText%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/copy/PlainText.cs/#L31" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/copy/PlainText.cs/#L31" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.CopyDetectors.SqlLog.html
+++ b/docs/html/api/AutoCheck.Core.CopyDetectors.SqlLog.html
@@ -344,7 +344,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_CopyDetectors_SqlLog__ctor_System_Single_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.CopyDetectors.SqlLog.%23ctor(System.Single%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/copy/SqlLog.cs/#L30">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/copy/SqlLog.cs/#L30">View Source</a>
   </span>
   <a id="AutoCheck_Core_CopyDetectors_SqlLog__ctor_" data-uid="AutoCheck.Core.CopyDetectors.SqlLog.#ctor*"></a>
   <h4 id="AutoCheck_Core_CopyDetectors_SqlLog__ctor_System_Single_System_String_" data-uid="AutoCheck.Core.CopyDetectors.SqlLog.#ctor(System.Single,System.String)">SqlLog(Single, String)</h4>
@@ -392,7 +392,7 @@
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_CopyDetectors_SqlLog.md&amp;value=---%0Auid%3A%20AutoCheck.Core.CopyDetectors.SqlLog%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/copy/SqlLog.cs/#L25" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/copy/SqlLog.cs/#L25" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.CopyDetectors.Xml.html
+++ b/docs/html/api/AutoCheck.Core.CopyDetectors.Xml.html
@@ -344,7 +344,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_CopyDetectors_Xml__ctor_System_Single_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.CopyDetectors.Xml.%23ctor(System.Single%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/copy/Xml.cs/#L29">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/copy/Xml.cs/#L29">View Source</a>
   </span>
   <a id="AutoCheck_Core_CopyDetectors_Xml__ctor_" data-uid="AutoCheck.Core.CopyDetectors.Xml.#ctor*"></a>
   <h4 id="AutoCheck_Core_CopyDetectors_Xml__ctor_System_Single_System_String_" data-uid="AutoCheck.Core.CopyDetectors.Xml.#ctor(System.Single,System.String)">Xml(Single, String)</h4>
@@ -392,7 +392,7 @@
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_CopyDetectors_Xml.md&amp;value=---%0Auid%3A%20AutoCheck.Core.CopyDetectors.Xml%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/copy/Xml.cs/#L25" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/copy/Xml.cs/#L25" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.Exceptions.ArgumentInvalidException.html
+++ b/docs/html/api/AutoCheck.Core.Exceptions.ArgumentInvalidException.html
@@ -296,7 +296,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_ArgumentInvalidException__ctor.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.ArgumentInvalidException.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L182">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L182">View Source</a>
   </span>
   <a id="AutoCheck_Core_Exceptions_ArgumentInvalidException__ctor_" data-uid="AutoCheck.Core.Exceptions.ArgumentInvalidException.#ctor*"></a>
   <h4 id="AutoCheck_Core_Exceptions_ArgumentInvalidException__ctor" data-uid="AutoCheck.Core.Exceptions.ArgumentInvalidException.#ctor">ArgumentInvalidException()</h4>
@@ -311,7 +311,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_ArgumentInvalidException__ctor_System_String_Exception_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.ArgumentInvalidException.%23ctor(System.String%2CException)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L183">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L183">View Source</a>
   </span>
   <a id="AutoCheck_Core_Exceptions_ArgumentInvalidException__ctor_" data-uid="AutoCheck.Core.Exceptions.ArgumentInvalidException.#ctor*"></a>
   <h4 id="AutoCheck_Core_Exceptions_ArgumentInvalidException__ctor_System_String_Exception_" data-uid="AutoCheck.Core.Exceptions.ArgumentInvalidException.#ctor(System.String,Exception)">ArgumentInvalidException(String, Exception)</h4>
@@ -358,7 +358,7 @@
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_ArgumentInvalidException.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.ArgumentInvalidException%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L176" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L176" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.Exceptions.ArgumentNotFoundException.html
+++ b/docs/html/api/AutoCheck.Core.Exceptions.ArgumentNotFoundException.html
@@ -297,7 +297,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_ArgumentNotFoundException__ctor.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.ArgumentNotFoundException.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L82">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L82">View Source</a>
   </span>
   <a id="AutoCheck_Core_Exceptions_ArgumentNotFoundException__ctor_" data-uid="AutoCheck.Core.Exceptions.ArgumentNotFoundException.#ctor*"></a>
   <h4 id="AutoCheck_Core_Exceptions_ArgumentNotFoundException__ctor" data-uid="AutoCheck.Core.Exceptions.ArgumentNotFoundException.#ctor">ArgumentNotFoundException()</h4>
@@ -312,7 +312,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_ArgumentNotFoundException__ctor_System_String_Exception_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.ArgumentNotFoundException.%23ctor(System.String%2CException)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L83">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L83">View Source</a>
   </span>
   <a id="AutoCheck_Core_Exceptions_ArgumentNotFoundException__ctor_" data-uid="AutoCheck.Core.Exceptions.ArgumentNotFoundException.#ctor*"></a>
   <h4 id="AutoCheck_Core_Exceptions_ArgumentNotFoundException__ctor_System_String_Exception_" data-uid="AutoCheck.Core.Exceptions.ArgumentNotFoundException.#ctor(System.String,Exception)">ArgumentNotFoundException(String, Exception)</h4>
@@ -359,7 +359,7 @@
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_ArgumentNotFoundException.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.ArgumentNotFoundException%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L76" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L76" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.Exceptions.ConnectionInvalidException.html
+++ b/docs/html/api/AutoCheck.Core.Exceptions.ConnectionInvalidException.html
@@ -296,7 +296,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_ConnectionInvalidException__ctor.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.ConnectionInvalidException.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L162">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L162">View Source</a>
   </span>
   <a id="AutoCheck_Core_Exceptions_ConnectionInvalidException__ctor_" data-uid="AutoCheck.Core.Exceptions.ConnectionInvalidException.#ctor*"></a>
   <h4 id="AutoCheck_Core_Exceptions_ConnectionInvalidException__ctor" data-uid="AutoCheck.Core.Exceptions.ConnectionInvalidException.#ctor">ConnectionInvalidException()</h4>
@@ -311,7 +311,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_ConnectionInvalidException__ctor_System_String_Exception_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.ConnectionInvalidException.%23ctor(System.String%2CException)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L163">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L163">View Source</a>
   </span>
   <a id="AutoCheck_Core_Exceptions_ConnectionInvalidException__ctor_" data-uid="AutoCheck.Core.Exceptions.ConnectionInvalidException.#ctor*"></a>
   <h4 id="AutoCheck_Core_Exceptions_ConnectionInvalidException__ctor_System_String_Exception_" data-uid="AutoCheck.Core.Exceptions.ConnectionInvalidException.#ctor(System.String,Exception)">ConnectionInvalidException(String, Exception)</h4>
@@ -358,7 +358,7 @@
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_ConnectionInvalidException.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.ConnectionInvalidException%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L156" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L156" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.Exceptions.ConnectorInvalidException.html
+++ b/docs/html/api/AutoCheck.Core.Exceptions.ConnectorInvalidException.html
@@ -296,7 +296,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_ConnectorInvalidException__ctor.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.ConnectorInvalidException.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L112">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L112">View Source</a>
   </span>
   <a id="AutoCheck_Core_Exceptions_ConnectorInvalidException__ctor_" data-uid="AutoCheck.Core.Exceptions.ConnectorInvalidException.#ctor*"></a>
   <h4 id="AutoCheck_Core_Exceptions_ConnectorInvalidException__ctor" data-uid="AutoCheck.Core.Exceptions.ConnectorInvalidException.#ctor">ConnectorInvalidException()</h4>
@@ -311,7 +311,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_ConnectorInvalidException__ctor_System_String_Exception_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.ConnectorInvalidException.%23ctor(System.String%2CException)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L113">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L113">View Source</a>
   </span>
   <a id="AutoCheck_Core_Exceptions_ConnectorInvalidException__ctor_" data-uid="AutoCheck.Core.Exceptions.ConnectorInvalidException.#ctor*"></a>
   <h4 id="AutoCheck_Core_Exceptions_ConnectorInvalidException__ctor_System_String_Exception_" data-uid="AutoCheck.Core.Exceptions.ConnectorInvalidException.#ctor(System.String,Exception)">ConnectorInvalidException(String, Exception)</h4>
@@ -358,7 +358,7 @@
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_ConnectorInvalidException.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.ConnectorInvalidException%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L106" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L106" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.Exceptions.ConnectorNotFoundException.html
+++ b/docs/html/api/AutoCheck.Core.Exceptions.ConnectorNotFoundException.html
@@ -297,7 +297,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_ConnectorNotFoundException__ctor.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.ConnectorNotFoundException.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L102">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L102">View Source</a>
   </span>
   <a id="AutoCheck_Core_Exceptions_ConnectorNotFoundException__ctor_" data-uid="AutoCheck.Core.Exceptions.ConnectorNotFoundException.#ctor*"></a>
   <h4 id="AutoCheck_Core_Exceptions_ConnectorNotFoundException__ctor" data-uid="AutoCheck.Core.Exceptions.ConnectorNotFoundException.#ctor">ConnectorNotFoundException()</h4>
@@ -312,7 +312,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_ConnectorNotFoundException__ctor_System_String_Exception_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.ConnectorNotFoundException.%23ctor(System.String%2CException)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L103">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L103">View Source</a>
   </span>
   <a id="AutoCheck_Core_Exceptions_ConnectorNotFoundException__ctor_" data-uid="AutoCheck.Core.Exceptions.ConnectorNotFoundException.#ctor*"></a>
   <h4 id="AutoCheck_Core_Exceptions_ConnectorNotFoundException__ctor_System_String_Exception_" data-uid="AutoCheck.Core.Exceptions.ConnectorNotFoundException.#ctor(System.String,Exception)">ConnectorNotFoundException(String, Exception)</h4>
@@ -359,7 +359,7 @@
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_ConnectorNotFoundException.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.ConnectorNotFoundException%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L96" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L96" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.Exceptions.DocumentInvalidException.html
+++ b/docs/html/api/AutoCheck.Core.Exceptions.DocumentInvalidException.html
@@ -296,7 +296,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_DocumentInvalidException__ctor.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.DocumentInvalidException.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L32">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L32">View Source</a>
   </span>
   <a id="AutoCheck_Core_Exceptions_DocumentInvalidException__ctor_" data-uid="AutoCheck.Core.Exceptions.DocumentInvalidException.#ctor*"></a>
   <h4 id="AutoCheck_Core_Exceptions_DocumentInvalidException__ctor" data-uid="AutoCheck.Core.Exceptions.DocumentInvalidException.#ctor">DocumentInvalidException()</h4>
@@ -311,7 +311,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_DocumentInvalidException__ctor_System_String_Exception_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.DocumentInvalidException.%23ctor(System.String%2CException)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L33">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L33">View Source</a>
   </span>
   <a id="AutoCheck_Core_Exceptions_DocumentInvalidException__ctor_" data-uid="AutoCheck.Core.Exceptions.DocumentInvalidException.#ctor*"></a>
   <h4 id="AutoCheck_Core_Exceptions_DocumentInvalidException__ctor_System_String_Exception_" data-uid="AutoCheck.Core.Exceptions.DocumentInvalidException.#ctor(System.String,Exception)">DocumentInvalidException(String, Exception)</h4>
@@ -358,7 +358,7 @@
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_DocumentInvalidException.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.DocumentInvalidException%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L26" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L26" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.Exceptions.DownloadFailedException.html
+++ b/docs/html/api/AutoCheck.Core.Exceptions.DownloadFailedException.html
@@ -296,7 +296,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_DownloadFailedException__ctor.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.DownloadFailedException.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L192">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L192">View Source</a>
   </span>
   <a id="AutoCheck_Core_Exceptions_DownloadFailedException__ctor_" data-uid="AutoCheck.Core.Exceptions.DownloadFailedException.#ctor*"></a>
   <h4 id="AutoCheck_Core_Exceptions_DownloadFailedException__ctor" data-uid="AutoCheck.Core.Exceptions.DownloadFailedException.#ctor">DownloadFailedException()</h4>
@@ -311,7 +311,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_DownloadFailedException__ctor_System_String_Exception_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.DownloadFailedException.%23ctor(System.String%2CException)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L193">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L193">View Source</a>
   </span>
   <a id="AutoCheck_Core_Exceptions_DownloadFailedException__ctor_" data-uid="AutoCheck.Core.Exceptions.DownloadFailedException.#ctor*"></a>
   <h4 id="AutoCheck_Core_Exceptions_DownloadFailedException__ctor_System_String_Exception_" data-uid="AutoCheck.Core.Exceptions.DownloadFailedException.#ctor(System.String,Exception)">DownloadFailedException(String, Exception)</h4>
@@ -358,7 +358,7 @@
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_DownloadFailedException.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.DownloadFailedException%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L186" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L186" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.Exceptions.ItemNotFoundException.html
+++ b/docs/html/api/AutoCheck.Core.Exceptions.ItemNotFoundException.html
@@ -300,7 +300,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_ItemNotFoundException__ctor.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.ItemNotFoundException.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L62">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L62">View Source</a>
   </span>
   <a id="AutoCheck_Core_Exceptions_ItemNotFoundException__ctor_" data-uid="AutoCheck.Core.Exceptions.ItemNotFoundException.#ctor*"></a>
   <h4 id="AutoCheck_Core_Exceptions_ItemNotFoundException__ctor" data-uid="AutoCheck.Core.Exceptions.ItemNotFoundException.#ctor">ItemNotFoundException()</h4>
@@ -315,7 +315,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_ItemNotFoundException__ctor_System_String_Exception_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.ItemNotFoundException.%23ctor(System.String%2CException)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L63">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L63">View Source</a>
   </span>
   <a id="AutoCheck_Core_Exceptions_ItemNotFoundException__ctor_" data-uid="AutoCheck.Core.Exceptions.ItemNotFoundException.#ctor*"></a>
   <h4 id="AutoCheck_Core_Exceptions_ItemNotFoundException__ctor_System_String_Exception_" data-uid="AutoCheck.Core.Exceptions.ItemNotFoundException.#ctor(System.String,Exception)">ItemNotFoundException(String, Exception)</h4>
@@ -362,7 +362,7 @@
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_ItemNotFoundException.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.ItemNotFoundException%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L56" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L56" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.Exceptions.PorpertyNotFoundException.html
+++ b/docs/html/api/AutoCheck.Core.Exceptions.PorpertyNotFoundException.html
@@ -297,7 +297,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_PorpertyNotFoundException__ctor.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.PorpertyNotFoundException.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L92">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L92">View Source</a>
   </span>
   <a id="AutoCheck_Core_Exceptions_PorpertyNotFoundException__ctor_" data-uid="AutoCheck.Core.Exceptions.PorpertyNotFoundException.#ctor*"></a>
   <h4 id="AutoCheck_Core_Exceptions_PorpertyNotFoundException__ctor" data-uid="AutoCheck.Core.Exceptions.PorpertyNotFoundException.#ctor">PorpertyNotFoundException()</h4>
@@ -312,7 +312,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_PorpertyNotFoundException__ctor_System_String_Exception_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.PorpertyNotFoundException.%23ctor(System.String%2CException)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L93">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L93">View Source</a>
   </span>
   <a id="AutoCheck_Core_Exceptions_PorpertyNotFoundException__ctor_" data-uid="AutoCheck.Core.Exceptions.PorpertyNotFoundException.#ctor*"></a>
   <h4 id="AutoCheck_Core_Exceptions_PorpertyNotFoundException__ctor_System_String_Exception_" data-uid="AutoCheck.Core.Exceptions.PorpertyNotFoundException.#ctor(System.String,Exception)">PorpertyNotFoundException(String, Exception)</h4>
@@ -359,7 +359,7 @@
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_PorpertyNotFoundException.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.PorpertyNotFoundException%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L86" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L86" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.Exceptions.QueryInvalidException.html
+++ b/docs/html/api/AutoCheck.Core.Exceptions.QueryInvalidException.html
@@ -296,7 +296,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_QueryInvalidException__ctor.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.QueryInvalidException.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L172">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L172">View Source</a>
   </span>
   <a id="AutoCheck_Core_Exceptions_QueryInvalidException__ctor_" data-uid="AutoCheck.Core.Exceptions.QueryInvalidException.#ctor*"></a>
   <h4 id="AutoCheck_Core_Exceptions_QueryInvalidException__ctor" data-uid="AutoCheck.Core.Exceptions.QueryInvalidException.#ctor">QueryInvalidException()</h4>
@@ -311,7 +311,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_QueryInvalidException__ctor_System_String_Exception_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.QueryInvalidException.%23ctor(System.String%2CException)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L173">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L173">View Source</a>
   </span>
   <a id="AutoCheck_Core_Exceptions_QueryInvalidException__ctor_" data-uid="AutoCheck.Core.Exceptions.QueryInvalidException.#ctor*"></a>
   <h4 id="AutoCheck_Core_Exceptions_QueryInvalidException__ctor_System_String_Exception_" data-uid="AutoCheck.Core.Exceptions.QueryInvalidException.#ctor(System.String,Exception)">QueryInvalidException(String, Exception)</h4>
@@ -358,7 +358,7 @@
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_QueryInvalidException.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.QueryInvalidException%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L166" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L166" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.Exceptions.RegexInvalidException.html
+++ b/docs/html/api/AutoCheck.Core.Exceptions.RegexInvalidException.html
@@ -296,7 +296,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_RegexInvalidException__ctor.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.RegexInvalidException.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L52">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L52">View Source</a>
   </span>
   <a id="AutoCheck_Core_Exceptions_RegexInvalidException__ctor_" data-uid="AutoCheck.Core.Exceptions.RegexInvalidException.#ctor*"></a>
   <h4 id="AutoCheck_Core_Exceptions_RegexInvalidException__ctor" data-uid="AutoCheck.Core.Exceptions.RegexInvalidException.#ctor">RegexInvalidException()</h4>
@@ -311,7 +311,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_RegexInvalidException__ctor_System_String_Exception_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.RegexInvalidException.%23ctor(System.String%2CException)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L53">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L53">View Source</a>
   </span>
   <a id="AutoCheck_Core_Exceptions_RegexInvalidException__ctor_" data-uid="AutoCheck.Core.Exceptions.RegexInvalidException.#ctor*"></a>
   <h4 id="AutoCheck_Core_Exceptions_RegexInvalidException__ctor_System_String_Exception_" data-uid="AutoCheck.Core.Exceptions.RegexInvalidException.#ctor(System.String,Exception)">RegexInvalidException(String, Exception)</h4>
@@ -358,7 +358,7 @@
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_RegexInvalidException.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.RegexInvalidException%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L46" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L46" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.Exceptions.ResultMismatchException.html
+++ b/docs/html/api/AutoCheck.Core.Exceptions.ResultMismatchException.html
@@ -296,7 +296,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_ResultMismatchException__ctor.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.ResultMismatchException.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L202">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L202">View Source</a>
   </span>
   <a id="AutoCheck_Core_Exceptions_ResultMismatchException__ctor_" data-uid="AutoCheck.Core.Exceptions.ResultMismatchException.#ctor*"></a>
   <h4 id="AutoCheck_Core_Exceptions_ResultMismatchException__ctor" data-uid="AutoCheck.Core.Exceptions.ResultMismatchException.#ctor">ResultMismatchException()</h4>
@@ -311,7 +311,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_ResultMismatchException__ctor_System_String_Exception_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.ResultMismatchException.%23ctor(System.String%2CException)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L203">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L203">View Source</a>
   </span>
   <a id="AutoCheck_Core_Exceptions_ResultMismatchException__ctor_" data-uid="AutoCheck.Core.Exceptions.ResultMismatchException.#ctor*"></a>
   <h4 id="AutoCheck_Core_Exceptions_ResultMismatchException__ctor_System_String_Exception_" data-uid="AutoCheck.Core.Exceptions.ResultMismatchException.#ctor(System.String,Exception)">ResultMismatchException(String, Exception)</h4>
@@ -358,7 +358,7 @@
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_ResultMismatchException.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.ResultMismatchException%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L196" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L196" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.Exceptions.StyleInvalidException.html
+++ b/docs/html/api/AutoCheck.Core.Exceptions.StyleInvalidException.html
@@ -296,7 +296,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_StyleInvalidException__ctor.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.StyleInvalidException.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L42">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L42">View Source</a>
   </span>
   <a id="AutoCheck_Core_Exceptions_StyleInvalidException__ctor_" data-uid="AutoCheck.Core.Exceptions.StyleInvalidException.#ctor*"></a>
   <h4 id="AutoCheck_Core_Exceptions_StyleInvalidException__ctor" data-uid="AutoCheck.Core.Exceptions.StyleInvalidException.#ctor">StyleInvalidException()</h4>
@@ -311,7 +311,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_StyleInvalidException__ctor_System_String_Exception_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.StyleInvalidException.%23ctor(System.String%2CException)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L43">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L43">View Source</a>
   </span>
   <a id="AutoCheck_Core_Exceptions_StyleInvalidException__ctor_" data-uid="AutoCheck.Core.Exceptions.StyleInvalidException.#ctor*"></a>
   <h4 id="AutoCheck_Core_Exceptions_StyleInvalidException__ctor_System_String_Exception_" data-uid="AutoCheck.Core.Exceptions.StyleInvalidException.#ctor(System.String,Exception)">StyleInvalidException(String, Exception)</h4>
@@ -358,7 +358,7 @@
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_StyleInvalidException.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.StyleInvalidException%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L36" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L36" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.Exceptions.StyleNotAppliedException.html
+++ b/docs/html/api/AutoCheck.Core.Exceptions.StyleNotAppliedException.html
@@ -296,7 +296,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_StyleNotAppliedException__ctor.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.StyleNotAppliedException.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L142">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L142">View Source</a>
   </span>
   <a id="AutoCheck_Core_Exceptions_StyleNotAppliedException__ctor_" data-uid="AutoCheck.Core.Exceptions.StyleNotAppliedException.#ctor*"></a>
   <h4 id="AutoCheck_Core_Exceptions_StyleNotAppliedException__ctor" data-uid="AutoCheck.Core.Exceptions.StyleNotAppliedException.#ctor">StyleNotAppliedException()</h4>
@@ -311,7 +311,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_StyleNotAppliedException__ctor_System_String_Exception_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.StyleNotAppliedException.%23ctor(System.String%2CException)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L143">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L143">View Source</a>
   </span>
   <a id="AutoCheck_Core_Exceptions_StyleNotAppliedException__ctor_" data-uid="AutoCheck.Core.Exceptions.StyleNotAppliedException.#ctor*"></a>
   <h4 id="AutoCheck_Core_Exceptions_StyleNotAppliedException__ctor_System_String_Exception_" data-uid="AutoCheck.Core.Exceptions.StyleNotAppliedException.#ctor(System.String,Exception)">StyleNotAppliedException(String, Exception)</h4>
@@ -358,7 +358,7 @@
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_StyleNotAppliedException.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.StyleNotAppliedException%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L136" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L136" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.Exceptions.StyleNotFoundException.html
+++ b/docs/html/api/AutoCheck.Core.Exceptions.StyleNotFoundException.html
@@ -296,7 +296,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_StyleNotFoundException__ctor.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.StyleNotFoundException.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L132">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L132">View Source</a>
   </span>
   <a id="AutoCheck_Core_Exceptions_StyleNotFoundException__ctor_" data-uid="AutoCheck.Core.Exceptions.StyleNotFoundException.#ctor*"></a>
   <h4 id="AutoCheck_Core_Exceptions_StyleNotFoundException__ctor" data-uid="AutoCheck.Core.Exceptions.StyleNotFoundException.#ctor">StyleNotFoundException()</h4>
@@ -311,7 +311,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_StyleNotFoundException__ctor_System_String_Exception_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.StyleNotFoundException.%23ctor(System.String%2CException)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L133">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L133">View Source</a>
   </span>
   <a id="AutoCheck_Core_Exceptions_StyleNotFoundException__ctor_" data-uid="AutoCheck.Core.Exceptions.StyleNotFoundException.#ctor*"></a>
   <h4 id="AutoCheck_Core_Exceptions_StyleNotFoundException__ctor_System_String_Exception_" data-uid="AutoCheck.Core.Exceptions.StyleNotFoundException.#ctor(System.String,Exception)">StyleNotFoundException(String, Exception)</h4>
@@ -358,7 +358,7 @@
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_StyleNotFoundException.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.StyleNotFoundException%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L126" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L126" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.Exceptions.TableInconsistencyException.html
+++ b/docs/html/api/AutoCheck.Core.Exceptions.TableInconsistencyException.html
@@ -296,7 +296,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_TableInconsistencyException__ctor.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.TableInconsistencyException.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L152">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L152">View Source</a>
   </span>
   <a id="AutoCheck_Core_Exceptions_TableInconsistencyException__ctor_" data-uid="AutoCheck.Core.Exceptions.TableInconsistencyException.#ctor*"></a>
   <h4 id="AutoCheck_Core_Exceptions_TableInconsistencyException__ctor" data-uid="AutoCheck.Core.Exceptions.TableInconsistencyException.#ctor">TableInconsistencyException()</h4>
@@ -311,7 +311,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_TableInconsistencyException__ctor_System_String_Exception_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.TableInconsistencyException.%23ctor(System.String%2CException)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L153">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L153">View Source</a>
   </span>
   <a id="AutoCheck_Core_Exceptions_TableInconsistencyException__ctor_" data-uid="AutoCheck.Core.Exceptions.TableInconsistencyException.#ctor*"></a>
   <h4 id="AutoCheck_Core_Exceptions_TableInconsistencyException__ctor_System_String_Exception_" data-uid="AutoCheck.Core.Exceptions.TableInconsistencyException.#ctor(System.String,Exception)">TableInconsistencyException(String, Exception)</h4>
@@ -358,7 +358,7 @@
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_TableInconsistencyException.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.TableInconsistencyException%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L146" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L146" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.Exceptions.VariableInvalidException.html
+++ b/docs/html/api/AutoCheck.Core.Exceptions.VariableInvalidException.html
@@ -296,7 +296,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_VariableInvalidException__ctor.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.VariableInvalidException.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L122">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L122">View Source</a>
   </span>
   <a id="AutoCheck_Core_Exceptions_VariableInvalidException__ctor_" data-uid="AutoCheck.Core.Exceptions.VariableInvalidException.#ctor*"></a>
   <h4 id="AutoCheck_Core_Exceptions_VariableInvalidException__ctor" data-uid="AutoCheck.Core.Exceptions.VariableInvalidException.#ctor">VariableInvalidException()</h4>
@@ -311,7 +311,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_VariableInvalidException__ctor_System_String_Exception_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.VariableInvalidException.%23ctor(System.String%2CException)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L123">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L123">View Source</a>
   </span>
   <a id="AutoCheck_Core_Exceptions_VariableInvalidException__ctor_" data-uid="AutoCheck.Core.Exceptions.VariableInvalidException.#ctor*"></a>
   <h4 id="AutoCheck_Core_Exceptions_VariableInvalidException__ctor_System_String_Exception_" data-uid="AutoCheck.Core.Exceptions.VariableInvalidException.#ctor(System.String,Exception)">VariableInvalidException(String, Exception)</h4>
@@ -358,7 +358,7 @@
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_VariableInvalidException.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.VariableInvalidException%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L116" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L116" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.Exceptions.VariableNotFoundException.html
+++ b/docs/html/api/AutoCheck.Core.Exceptions.VariableNotFoundException.html
@@ -297,7 +297,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_VariableNotFoundException__ctor.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.VariableNotFoundException.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L72">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L72">View Source</a>
   </span>
   <a id="AutoCheck_Core_Exceptions_VariableNotFoundException__ctor_" data-uid="AutoCheck.Core.Exceptions.VariableNotFoundException.#ctor*"></a>
   <h4 id="AutoCheck_Core_Exceptions_VariableNotFoundException__ctor" data-uid="AutoCheck.Core.Exceptions.VariableNotFoundException.#ctor">VariableNotFoundException()</h4>
@@ -312,7 +312,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_VariableNotFoundException__ctor_System_String_Exception_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.VariableNotFoundException.%23ctor(System.String%2CException)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L73">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L73">View Source</a>
   </span>
   <a id="AutoCheck_Core_Exceptions_VariableNotFoundException__ctor_" data-uid="AutoCheck.Core.Exceptions.VariableNotFoundException.#ctor*"></a>
   <h4 id="AutoCheck_Core_Exceptions_VariableNotFoundException__ctor_System_String_Exception_" data-uid="AutoCheck.Core.Exceptions.VariableNotFoundException.#ctor(System.String,Exception)">VariableNotFoundException(String, Exception)</h4>
@@ -359,7 +359,7 @@
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Exceptions_VariableNotFoundException.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Exceptions.VariableNotFoundException%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Exceptions.cs/#L66" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Exceptions.cs/#L66" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.Output.Log.html
+++ b/docs/html/api/AutoCheck.Core.Output.Log.html
@@ -296,7 +296,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Output_Log__ctor.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Output.Log.%23ctor%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Output.cs/#L49">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Output.cs/#L49">View Source</a>
   </span>
   <a id="AutoCheck_Core_Output_Log__ctor_" data-uid="AutoCheck.Core.Output.Log.#ctor*"></a>
   <h4 id="AutoCheck_Core_Output_Log__ctor" data-uid="AutoCheck.Core.Output.Log.#ctor">Log()</h4>
@@ -313,7 +313,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Output_Log_ToJson.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Output.Log.ToJson%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Output.cs/#L76">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Output.cs/#L76">View Source</a>
   </span>
   <a id="AutoCheck_Core_Output_Log_ToJson_" data-uid="AutoCheck.Core.Output.Log.ToJson*"></a>
   <h4 id="AutoCheck_Core_Output_Log_ToJson" data-uid="AutoCheck.Core.Output.Log.ToJson">ToJson()</h4>
@@ -344,7 +344,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Output_Log_ToText.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Output.Log.ToText%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Output.cs/#L57">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Output.cs/#L57">View Source</a>
   </span>
   <a id="AutoCheck_Core_Output_Log_ToText_" data-uid="AutoCheck.Core.Output.Log.ToText*"></a>
   <h4 id="AutoCheck_Core_Output_Log_ToText" data-uid="AutoCheck.Core.Output.Log.ToText">ToText()</h4>
@@ -385,7 +385,7 @@
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Output_Log.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Output.Log%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Output.cs/#L46" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Output.cs/#L46" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.Output.Style.html
+++ b/docs/html/api/AutoCheck.Core.Output.Style.html
@@ -359,7 +359,7 @@
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Output_Style.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Output.Style%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Output.cs/#L83" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Output.cs/#L83" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.Output.Type.html
+++ b/docs/html/api/AutoCheck.Core.Output.Type.html
@@ -327,7 +327,7 @@
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Output_Type.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Output.Type%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Output.cs/#L98" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Output.cs/#L98" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.Output.html
+++ b/docs/html/api/AutoCheck.Core.Output.html
@@ -300,7 +300,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Output__ctor_System_Boolean_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Output.%23ctor(System.Boolean)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Output.cs/#L131">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Output.cs/#L131">View Source</a>
   </span>
   <a id="AutoCheck_Core_Output__ctor_" data-uid="AutoCheck.Core.Output.#ctor*"></a>
   <h4 id="AutoCheck_Core_Output__ctor_System_Boolean_" data-uid="AutoCheck.Core.Output.#ctor(System.Boolean)">Output(Boolean)</h4>
@@ -336,7 +336,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Output_SingleIndent.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Output.SingleIndent%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Output.cs/#L114">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Output.cs/#L114">View Source</a>
   </span>
   <h4 id="AutoCheck_Core_Output_SingleIndent" data-uid="AutoCheck.Core.Output.SingleIndent">SingleIndent</h4>
   <div class="markdown level1 summary"></div>
@@ -367,7 +367,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Output_CurrentIndent.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Output.CurrentIndent%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Output.cs/#L116">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Output.cs/#L116">View Source</a>
   </span>
   <a id="AutoCheck_Core_Output_CurrentIndent_" data-uid="AutoCheck.Core.Output.CurrentIndent*"></a>
   <h4 id="AutoCheck_Core_Output_CurrentIndent" data-uid="AutoCheck.Core.Output.CurrentIndent">CurrentIndent</h4>
@@ -399,7 +399,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Output_BreakLine_System_Int32_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Output.BreakLine(System.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Output.cs/#L222">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Output.cs/#L222">View Source</a>
   </span>
   <a id="AutoCheck_Core_Output_BreakLine_" data-uid="AutoCheck.Core.Output.BreakLine*"></a>
   <h4 id="AutoCheck_Core_Output_BreakLine_System_Int32_" data-uid="AutoCheck.Core.Output.BreakLine(System.Int32)">BreakLine(Int32)</h4>
@@ -433,7 +433,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Output_CloseLog.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Output.CloseLog%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Output.cs/#L232">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Output.cs/#L232">View Source</a>
   </span>
   <a id="AutoCheck_Core_Output_CloseLog_" data-uid="AutoCheck.Core.Output.CloseLog*"></a>
   <h4 id="AutoCheck_Core_Output_CloseLog" data-uid="AutoCheck.Core.Output.CloseLog">CloseLog()</h4>
@@ -465,7 +465,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Output_GetLog.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Output.GetLog%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Output.cs/#L244">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Output.cs/#L244">View Source</a>
   </span>
   <a id="AutoCheck_Core_Output_GetLog_" data-uid="AutoCheck.Core.Output.GetLog*"></a>
   <h4 id="AutoCheck_Core_Output_GetLog" data-uid="AutoCheck.Core.Output.GetLog">GetLog()</h4>
@@ -496,7 +496,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Output_Indent.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Output.Indent%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Output.cs/#L199">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Output.cs/#L199">View Source</a>
   </span>
   <a id="AutoCheck_Core_Output_Indent_" data-uid="AutoCheck.Core.Output.Indent*"></a>
   <h4 id="AutoCheck_Core_Output_Indent" data-uid="AutoCheck.Core.Output.Indent">Indent()</h4>
@@ -512,7 +512,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Output_ResetIndent.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Output.ResetIndent%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Output.cs/#L213">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Output.cs/#L213">View Source</a>
   </span>
   <a id="AutoCheck_Core_Output_ResetIndent_" data-uid="AutoCheck.Core.Output.ResetIndent*"></a>
   <h4 id="AutoCheck_Core_Output_ResetIndent" data-uid="AutoCheck.Core.Output.ResetIndent">ResetIndent()</h4>
@@ -528,7 +528,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Output_SendToTerminal_AutoCheck_Core_Output_Log_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Output.SendToTerminal(AutoCheck.Core.Output.Log)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Output.cs/#L283">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Output.cs/#L283">View Source</a>
   </span>
   <a id="AutoCheck_Core_Output_SendToTerminal_" data-uid="AutoCheck.Core.Output.SendToTerminal*"></a>
   <h4 id="AutoCheck_Core_Output_SendToTerminal_AutoCheck_Core_Output_Log_" data-uid="AutoCheck.Core.Output.SendToTerminal(AutoCheck.Core.Output.Log)">SendToTerminal(Output.Log)</h4>
@@ -562,7 +562,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Output_ToString.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Output.ToString%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Output.cs/#L275">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Output.cs/#L275">View Source</a>
   </span>
   <a id="AutoCheck_Core_Output_ToString_" data-uid="AutoCheck.Core.Output.ToString*"></a>
   <h4 id="AutoCheck_Core_Output_ToString" data-uid="AutoCheck.Core.Output.ToString">ToString()</h4>
@@ -593,7 +593,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Output_UnIndent.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Output.UnIndent%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Output.cs/#L206">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Output.cs/#L206">View Source</a>
   </span>
   <a id="AutoCheck_Core_Output_UnIndent_" data-uid="AutoCheck.Core.Output.UnIndent*"></a>
   <h4 id="AutoCheck_Core_Output_UnIndent" data-uid="AutoCheck.Core.Output.UnIndent">UnIndent()</h4>
@@ -609,7 +609,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Output_Write_System_String_AutoCheck_Core_Output_Style_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Output.Write(System.String%2CAutoCheck.Core.Output.Style)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Output.cs/#L157">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Output.cs/#L157">View Source</a>
   </span>
   <a id="AutoCheck_Core_Output_Write_" data-uid="AutoCheck.Core.Output.Write*"></a>
   <h4 id="AutoCheck_Core_Output_Write_System_String_AutoCheck_Core_Output_Style_" data-uid="AutoCheck.Core.Output.Write(System.String,AutoCheck.Core.Output.Style)">Write(String, Output.Style)</h4>
@@ -650,7 +650,7 @@ The text will be printed in gray, and everything between '~' symbols will be pri
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Output_WriteLine_System_String_AutoCheck_Core_Output_Style_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Output.WriteLine(System.String%2CAutoCheck.Core.Output.Style)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Output.cs/#L167">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Output.cs/#L167">View Source</a>
   </span>
   <a id="AutoCheck_Core_Output_WriteLine_" data-uid="AutoCheck.Core.Output.WriteLine*"></a>
   <h4 id="AutoCheck_Core_Output_WriteLine_System_String_AutoCheck_Core_Output_Style_" data-uid="AutoCheck.Core.Output.WriteLine(System.String,AutoCheck.Core.Output.Style)">WriteLine(String, Output.Style)</h4>
@@ -691,7 +691,7 @@ The text will be printed in gray, and everything between '~' symbols will be pri
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Output_WriteResponse_List_System_String__System_String_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Output.WriteResponse(List%7BSystem.String%7D%2CSystem.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Output.cs/#L176">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Output.cs/#L176">View Source</a>
   </span>
   <a id="AutoCheck_Core_Output_WriteResponse_" data-uid="AutoCheck.Core.Output.WriteResponse*"></a>
   <h4 id="AutoCheck_Core_Output_WriteResponse_List_System_String__System_String_System_String_" data-uid="AutoCheck.Core.Output.WriteResponse(List{System.String},System.String,System.String)">WriteResponse(List&lt;String&gt;, String, String)</h4>
@@ -736,7 +736,7 @@ The text will be printed in gray, and everything between '~' symbols will be pri
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Output_WriteResponse_System_String_System_String_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Output.WriteResponse(System.String%2CSystem.String%2CSystem.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Output.cs/#L192">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Output.cs/#L192">View Source</a>
   </span>
   <a id="AutoCheck_Core_Output_WriteResponse_" data-uid="AutoCheck.Core.Output.WriteResponse*"></a>
   <h4 id="AutoCheck_Core_Output_WriteResponse_System_String_System_String_System_String_" data-uid="AutoCheck.Core.Output.WriteResponse(System.String,System.String,System.String)">WriteResponse(String, String, String)</h4>
@@ -790,7 +790,7 @@ The text will be printed in gray, and everything between '~' symbols will be pri
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Output.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Output%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Output.cs/#L35" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Output.cs/#L35" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.Script.ExecutionModeType.html
+++ b/docs/html/api/AutoCheck.Core.Script.ExecutionModeType.html
@@ -319,7 +319,7 @@
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script_ExecutionModeType.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script.ExecutionModeType%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L71" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L71" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.Script.LogGeneratedEventArgs.html
+++ b/docs/html/api/AutoCheck.Core.Script.LogGeneratedEventArgs.html
@@ -296,7 +296,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script_LogGeneratedEventArgs_ExecutionMode.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script.LogGeneratedEventArgs.ExecutionMode%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L587">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L587">View Source</a>
   </span>
   <a id="AutoCheck_Core_Script_LogGeneratedEventArgs_ExecutionMode_" data-uid="AutoCheck.Core.Script.LogGeneratedEventArgs.ExecutionMode*"></a>
   <h4 id="AutoCheck_Core_Script_LogGeneratedEventArgs_ExecutionMode" data-uid="AutoCheck.Core.Script.LogGeneratedEventArgs.ExecutionMode">ExecutionMode</h4>
@@ -326,7 +326,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script_LogGeneratedEventArgs_Log.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script.LogGeneratedEventArgs.Log%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L588">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L588">View Source</a>
   </span>
   <a id="AutoCheck_Core_Script_LogGeneratedEventArgs_Log_" data-uid="AutoCheck.Core.Script.LogGeneratedEventArgs.Log*"></a>
   <h4 id="AutoCheck_Core_Script_LogGeneratedEventArgs_Log" data-uid="AutoCheck.Core.Script.LogGeneratedEventArgs.Log">Log</h4>
@@ -356,7 +356,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script_LogGeneratedEventArgs_Type.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script.LogGeneratedEventArgs.Type%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L586">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L586">View Source</a>
   </span>
   <a id="AutoCheck_Core_Script_LogGeneratedEventArgs_Type_" data-uid="AutoCheck.Core.Script.LogGeneratedEventArgs.Type*"></a>
   <h4 id="AutoCheck_Core_Script_LogGeneratedEventArgs_Type" data-uid="AutoCheck.Core.Script.LogGeneratedEventArgs.Type">Type</h4>
@@ -396,7 +396,7 @@
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script_LogGeneratedEventArgs.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script.LogGeneratedEventArgs%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L584" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L584" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.Script.html
+++ b/docs/html/api/AutoCheck.Core.Script.html
@@ -296,7 +296,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script__ctor_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script.%23ctor(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L636">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L636">View Source</a>
   </span>
   <a id="AutoCheck_Core_Script__ctor_" data-uid="AutoCheck.Core.Script.#ctor*"></a>
   <h4 id="AutoCheck_Core_Script__ctor_System_String_" data-uid="AutoCheck.Core.Script.#ctor(System.String)">Script(String)</h4>
@@ -328,7 +328,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script__ctor_System_String_EventHandler_AutoCheck_Core_Script_LogGeneratedEventArgs__.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script.%23ctor(System.String%2CEventHandler%7BAutoCheck.Core.Script.LogGeneratedEventArgs%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L643">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L643">View Source</a>
   </span>
   <a id="AutoCheck_Core_Script__ctor_" data-uid="AutoCheck.Core.Script.#ctor*"></a>
   <h4 id="AutoCheck_Core_Script__ctor_System_String_EventHandler_AutoCheck_Core_Script_LogGeneratedEventArgs__" data-uid="AutoCheck.Core.Script.#ctor(System.String,EventHandler{AutoCheck.Core.Script.LogGeneratedEventArgs})">Script(String, EventHandler&lt;Script.LogGeneratedEventArgs&gt;)</h4>
@@ -365,7 +365,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script__ctor_System_String_EventHandler_AutoCheck_Core_Script_LogGeneratedEventArgs__EventHandler_AutoCheck_Core_Script_LogGeneratedEventArgs__EventHandler_AutoCheck_Core_Script_LogGeneratedEventArgs__EventHandler_AutoCheck_Core_Script_LogGeneratedEventArgs__.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script.%23ctor(System.String%2CEventHandler%7BAutoCheck.Core.Script.LogGeneratedEventArgs%7D%2CEventHandler%7BAutoCheck.Core.Script.LogGeneratedEventArgs%7D%2CEventHandler%7BAutoCheck.Core.Script.LogGeneratedEventArgs%7D%2CEventHandler%7BAutoCheck.Core.Script.LogGeneratedEventArgs%7D)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L654">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L654">View Source</a>
   </span>
   <a id="AutoCheck_Core_Script__ctor_" data-uid="AutoCheck.Core.Script.#ctor*"></a>
   <h4 id="AutoCheck_Core_Script__ctor_System_String_EventHandler_AutoCheck_Core_Script_LogGeneratedEventArgs__EventHandler_AutoCheck_Core_Script_LogGeneratedEventArgs__EventHandler_AutoCheck_Core_Script_LogGeneratedEventArgs__EventHandler_AutoCheck_Core_Script_LogGeneratedEventArgs__" data-uid="AutoCheck.Core.Script.#ctor(System.String,EventHandler{AutoCheck.Core.Script.LogGeneratedEventArgs},EventHandler{AutoCheck.Core.Script.LogGeneratedEventArgs},EventHandler{AutoCheck.Core.Script.LogGeneratedEventArgs},EventHandler{AutoCheck.Core.Script.LogGeneratedEventArgs})">Script(String, EventHandler&lt;Script.LogGeneratedEventArgs&gt;, EventHandler&lt;Script.LogGeneratedEventArgs&gt;, EventHandler&lt;Script.LogGeneratedEventArgs&gt;, EventHandler&lt;Script.LogGeneratedEventArgs&gt;)</h4>
@@ -425,7 +425,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script_AppFolderName.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script.AppFolderName%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L166">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L166">View Source</a>
   </span>
   <a id="AutoCheck_Core_Script_AppFolderName_" data-uid="AutoCheck.Core.Script.AppFolderName*"></a>
   <h4 id="AutoCheck_Core_Script_AppFolderName" data-uid="AutoCheck.Core.Script.AppFolderName">AppFolderName</h4>
@@ -456,7 +456,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script_AppFolderPath.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script.AppFolderPath%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L145">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L145">View Source</a>
   </span>
   <a id="AutoCheck_Core_Script_AppFolderPath_" data-uid="AutoCheck.Core.Script.AppFolderPath*"></a>
   <h4 id="AutoCheck_Core_Script_AppFolderPath" data-uid="AutoCheck.Core.Script.AppFolderPath">AppFolderPath</h4>
@@ -487,7 +487,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script_BatchCaption.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script.BatchCaption%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L132">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L132">View Source</a>
   </span>
   <a id="AutoCheck_Core_Script_BatchCaption_" data-uid="AutoCheck.Core.Script.BatchCaption*"></a>
   <h4 id="AutoCheck_Core_Script_BatchCaption" data-uid="AutoCheck.Core.Script.BatchCaption">BatchCaption</h4>
@@ -518,7 +518,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script_Concurrent.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script.Concurrent%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L528">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L528">View Source</a>
   </span>
   <a id="AutoCheck_Core_Script_Concurrent_" data-uid="AutoCheck.Core.Script.Concurrent*"></a>
   <h4 id="AutoCheck_Core_Script_Concurrent" data-uid="AutoCheck.Core.Script.Concurrent">Concurrent</h4>
@@ -549,7 +549,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script_CurrentFileName.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script.CurrentFileName%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L299">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L299">View Source</a>
   </span>
   <a id="AutoCheck_Core_Script_CurrentFileName_" data-uid="AutoCheck.Core.Script.CurrentFileName*"></a>
   <h4 id="AutoCheck_Core_Script_CurrentFileName" data-uid="AutoCheck.Core.Script.CurrentFileName">CurrentFileName</h4>
@@ -580,7 +580,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script_CurrentFilePath.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script.CurrentFilePath%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L281">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L281">View Source</a>
   </span>
   <a id="AutoCheck_Core_Script_CurrentFilePath_" data-uid="AutoCheck.Core.Script.CurrentFilePath*"></a>
   <h4 id="AutoCheck_Core_Script_CurrentFilePath" data-uid="AutoCheck.Core.Script.CurrentFilePath">CurrentFilePath</h4>
@@ -611,7 +611,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script_CurrentFolderName.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script.CurrentFolderName%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L272">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L272">View Source</a>
   </span>
   <a id="AutoCheck_Core_Script_CurrentFolderName_" data-uid="AutoCheck.Core.Script.CurrentFolderName*"></a>
   <h4 id="AutoCheck_Core_Script_CurrentFolderName" data-uid="AutoCheck.Core.Script.CurrentFolderName">CurrentFolderName</h4>
@@ -642,7 +642,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script_CurrentFolderPath.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script.CurrentFolderPath%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L253">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L253">View Source</a>
   </span>
   <a id="AutoCheck_Core_Script_CurrentFolderPath_" data-uid="AutoCheck.Core.Script.CurrentFolderPath*"></a>
   <h4 id="AutoCheck_Core_Script_CurrentFolderPath" data-uid="AutoCheck.Core.Script.CurrentFolderPath">CurrentFolderPath</h4>
@@ -673,7 +673,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script_CurrentHost.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script.CurrentHost%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L393">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L393">View Source</a>
   </span>
   <a id="AutoCheck_Core_Script_CurrentHost_" data-uid="AutoCheck.Core.Script.CurrentHost*"></a>
   <h4 id="AutoCheck_Core_Script_CurrentHost" data-uid="AutoCheck.Core.Script.CurrentHost">CurrentHost</h4>
@@ -704,7 +704,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script_CurrentOS.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script.CurrentOS%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L380">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L380">View Source</a>
   </span>
   <a id="AutoCheck_Core_Script_CurrentOS_" data-uid="AutoCheck.Core.Script.CurrentOS*"></a>
   <h4 id="AutoCheck_Core_Script_CurrentOS" data-uid="AutoCheck.Core.Script.CurrentOS">CurrentOS</h4>
@@ -735,7 +735,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script_CurrentPassword.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script.CurrentPassword%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L419">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L419">View Source</a>
   </span>
   <a id="AutoCheck_Core_Script_CurrentPassword_" data-uid="AutoCheck.Core.Script.CurrentPassword*"></a>
   <h4 id="AutoCheck_Core_Script_CurrentPassword" data-uid="AutoCheck.Core.Script.CurrentPassword">CurrentPassword</h4>
@@ -766,7 +766,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script_CurrentPort.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script.CurrentPort%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L432">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L432">View Source</a>
   </span>
   <a id="AutoCheck_Core_Script_CurrentPort_" data-uid="AutoCheck.Core.Script.CurrentPort*"></a>
   <h4 id="AutoCheck_Core_Script_CurrentPort" data-uid="AutoCheck.Core.Script.CurrentPort">CurrentPort</h4>
@@ -797,7 +797,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script_CurrentQuestion.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script.CurrentQuestion%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L445">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L445">View Source</a>
   </span>
   <a id="AutoCheck_Core_Script_CurrentQuestion_" data-uid="AutoCheck.Core.Script.CurrentQuestion*"></a>
   <h4 id="AutoCheck_Core_Script_CurrentQuestion" data-uid="AutoCheck.Core.Script.CurrentQuestion">CurrentQuestion</h4>
@@ -828,7 +828,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script_CurrentScore.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script.CurrentScore%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L489">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L489">View Source</a>
   </span>
   <a id="AutoCheck_Core_Script_CurrentScore_" data-uid="AutoCheck.Core.Script.CurrentScore*"></a>
   <h4 id="AutoCheck_Core_Script_CurrentScore" data-uid="AutoCheck.Core.Script.CurrentScore">CurrentScore</h4>
@@ -859,7 +859,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script_CurrentTarget.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script.CurrentTarget%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L367">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L367">View Source</a>
   </span>
   <a id="AutoCheck_Core_Script_CurrentTarget_" data-uid="AutoCheck.Core.Script.CurrentTarget*"></a>
   <h4 id="AutoCheck_Core_Script_CurrentTarget" data-uid="AutoCheck.Core.Script.CurrentTarget">CurrentTarget</h4>
@@ -890,7 +890,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script_CurrentUser.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script.CurrentUser%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L406">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L406">View Source</a>
   </span>
   <a id="AutoCheck_Core_Script_CurrentUser_" data-uid="AutoCheck.Core.Script.CurrentUser*"></a>
   <h4 id="AutoCheck_Core_Script_CurrentUser" data-uid="AutoCheck.Core.Script.CurrentUser">CurrentUser</h4>
@@ -921,7 +921,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script_ExecutionFolderName.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script.ExecutionFolderName%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L189">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L189">View Source</a>
   </span>
   <a id="AutoCheck_Core_Script_ExecutionFolderName_" data-uid="AutoCheck.Core.Script.ExecutionFolderName*"></a>
   <h4 id="AutoCheck_Core_Script_ExecutionFolderName" data-uid="AutoCheck.Core.Script.ExecutionFolderName">ExecutionFolderName</h4>
@@ -952,7 +952,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script_ExecutionFolderPath.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script.ExecutionFolderPath%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L175">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L175">View Source</a>
   </span>
   <a id="AutoCheck_Core_Script_ExecutionFolderPath_" data-uid="AutoCheck.Core.Script.ExecutionFolderPath*"></a>
   <h4 id="AutoCheck_Core_Script_ExecutionFolderPath" data-uid="AutoCheck.Core.Script.ExecutionFolderPath">ExecutionFolderPath</h4>
@@ -983,7 +983,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script_LogFileName.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script.LogFileName%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L357">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L357">View Source</a>
   </span>
   <a id="AutoCheck_Core_Script_LogFileName_" data-uid="AutoCheck.Core.Script.LogFileName*"></a>
   <h4 id="AutoCheck_Core_Script_LogFileName" data-uid="AutoCheck.Core.Script.LogFileName">LogFileName</h4>
@@ -1014,7 +1014,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script_LogFilePath.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script.LogFilePath%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L338">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L338">View Source</a>
   </span>
   <a id="AutoCheck_Core_Script_LogFilePath_" data-uid="AutoCheck.Core.Script.LogFilePath*"></a>
   <h4 id="AutoCheck_Core_Script_LogFilePath" data-uid="AutoCheck.Core.Script.LogFilePath">LogFilePath</h4>
@@ -1045,7 +1045,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script_LogFiles.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script.LogFiles%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L547">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L547">View Source</a>
   </span>
   <a id="AutoCheck_Core_Script_LogFiles_" data-uid="AutoCheck.Core.Script.LogFiles*"></a>
   <h4 id="AutoCheck_Core_Script_LogFiles" data-uid="AutoCheck.Core.Script.LogFiles">LogFiles</h4>
@@ -1076,7 +1076,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script_LogFolderName.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script.LogFolderName%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L328">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L328">View Source</a>
   </span>
   <a id="AutoCheck_Core_Script_LogFolderName_" data-uid="AutoCheck.Core.Script.LogFolderName*"></a>
   <h4 id="AutoCheck_Core_Script_LogFolderName" data-uid="AutoCheck.Core.Script.LogFolderName">LogFolderName</h4>
@@ -1107,7 +1107,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script_LogFolderPath.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script.LogFolderPath%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L308">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L308">View Source</a>
   </span>
   <a id="AutoCheck_Core_Script_LogFolderPath_" data-uid="AutoCheck.Core.Script.LogFolderPath*"></a>
   <h4 id="AutoCheck_Core_Script_LogFolderPath" data-uid="AutoCheck.Core.Script.LogFolderPath">LogFolderPath</h4>
@@ -1138,7 +1138,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script_MaxScore.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script.MaxScore%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L502">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L502">View Source</a>
   </span>
   <a id="AutoCheck_Core_Script_MaxScore_" data-uid="AutoCheck.Core.Script.MaxScore*"></a>
   <h4 id="AutoCheck_Core_Script_MaxScore" data-uid="AutoCheck.Core.Script.MaxScore">MaxScore</h4>
@@ -1169,7 +1169,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script_Now.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script.Now%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L480">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L480">View Source</a>
   </span>
   <a id="AutoCheck_Core_Script_Now_" data-uid="AutoCheck.Core.Script.Now*"></a>
   <h4 id="AutoCheck_Core_Script_Now" data-uid="AutoCheck.Core.Script.Now">Now</h4>
@@ -1200,7 +1200,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script_Output.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script.Output%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L542">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L542">View Source</a>
   </span>
   <a id="AutoCheck_Core_Script_Output_" data-uid="AutoCheck.Core.Script.Output*"></a>
   <h4 id="AutoCheck_Core_Script_Output" data-uid="AutoCheck.Core.Script.Output">Output</h4>
@@ -1231,7 +1231,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script_Result.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script.Result%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L459">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L459">View Source</a>
   </span>
   <a id="AutoCheck_Core_Script_Result_" data-uid="AutoCheck.Core.Script.Result*"></a>
   <h4 id="AutoCheck_Core_Script_Result" data-uid="AutoCheck.Core.Script.Result">Result</h4>
@@ -1262,7 +1262,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script_ScriptCaption.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script.ScriptCaption%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L106">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L106">View Source</a>
   </span>
   <a id="AutoCheck_Core_Script_ScriptCaption_" data-uid="AutoCheck.Core.Script.ScriptCaption*"></a>
   <h4 id="AutoCheck_Core_Script_ScriptCaption" data-uid="AutoCheck.Core.Script.ScriptCaption">ScriptCaption</h4>
@@ -1293,7 +1293,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script_ScriptFileName.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script.ScriptFileName%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L244">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L244">View Source</a>
   </span>
   <a id="AutoCheck_Core_Script_ScriptFileName_" data-uid="AutoCheck.Core.Script.ScriptFileName*"></a>
   <h4 id="AutoCheck_Core_Script_ScriptFileName" data-uid="AutoCheck.Core.Script.ScriptFileName">ScriptFileName</h4>
@@ -1324,7 +1324,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script_ScriptFilePath.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script.ScriptFilePath%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L226">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L226">View Source</a>
   </span>
   <a id="AutoCheck_Core_Script_ScriptFilePath_" data-uid="AutoCheck.Core.Script.ScriptFilePath*"></a>
   <h4 id="AutoCheck_Core_Script_ScriptFilePath" data-uid="AutoCheck.Core.Script.ScriptFilePath">ScriptFilePath</h4>
@@ -1355,7 +1355,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script_ScriptFolderName.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script.ScriptFolderName%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L217">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L217">View Source</a>
   </span>
   <a id="AutoCheck_Core_Script_ScriptFolderName_" data-uid="AutoCheck.Core.Script.ScriptFolderName*"></a>
   <h4 id="AutoCheck_Core_Script_ScriptFolderName" data-uid="AutoCheck.Core.Script.ScriptFolderName">ScriptFolderName</h4>
@@ -1386,7 +1386,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script_ScriptFolderPath.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script.ScriptFolderPath%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L198">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L198">View Source</a>
   </span>
   <a id="AutoCheck_Core_Script_ScriptFolderPath_" data-uid="AutoCheck.Core.Script.ScriptFolderPath*"></a>
   <h4 id="AutoCheck_Core_Script_ScriptFolderPath" data-uid="AutoCheck.Core.Script.ScriptFolderPath">ScriptFolderPath</h4>
@@ -1417,7 +1417,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script_ScriptName.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script.ScriptName%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L80">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L80">View Source</a>
   </span>
   <a id="AutoCheck_Core_Script_ScriptName_" data-uid="AutoCheck.Core.Script.ScriptName*"></a>
   <h4 id="AutoCheck_Core_Script_ScriptName" data-uid="AutoCheck.Core.Script.ScriptName">ScriptName</h4>
@@ -1448,7 +1448,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script_ScriptVersion.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script.ScriptVersion%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L93">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L93">View Source</a>
   </span>
   <a id="AutoCheck_Core_Script_ScriptVersion_" data-uid="AutoCheck.Core.Script.ScriptVersion*"></a>
   <h4 id="AutoCheck_Core_Script_ScriptVersion" data-uid="AutoCheck.Core.Script.ScriptVersion">ScriptVersion</h4>
@@ -1479,7 +1479,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script_SingleCaption.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script.SingleCaption%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L119">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L119">View Source</a>
   </span>
   <a id="AutoCheck_Core_Script_SingleCaption_" data-uid="AutoCheck.Core.Script.SingleCaption*"></a>
   <h4 id="AutoCheck_Core_Script_SingleCaption" data-uid="AutoCheck.Core.Script.SingleCaption">SingleCaption</h4>
@@ -1510,7 +1510,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script_TotalScore.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script.TotalScore%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L515">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L515">View Source</a>
   </span>
   <a id="AutoCheck_Core_Script_TotalScore_" data-uid="AutoCheck.Core.Script.TotalScore*"></a>
   <h4 id="AutoCheck_Core_Script_TotalScore" data-uid="AutoCheck.Core.Script.TotalScore">TotalScore</h4>
@@ -1551,7 +1551,7 @@
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Script.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Script%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Script.cs/#L38" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Script.cs/#L38" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.Utils.OS.html
+++ b/docs/html/api/AutoCheck.Core.Utils.OS.html
@@ -323,7 +323,7 @@
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Utils_OS.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Utils.OS%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Utils.cs/#L30" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Utils.cs/#L30" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/api/AutoCheck.Core.Utils.html
+++ b/docs/html/api/AutoCheck.Core.Utils.html
@@ -296,7 +296,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Utils_AppFolder.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Utils.AppFolder%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Utils.cs/#L41">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Utils.cs/#L41">View Source</a>
   </span>
   <a id="AutoCheck_Core_Utils_AppFolder_" data-uid="AutoCheck.Core.Utils.AppFolder*"></a>
   <h4 id="AutoCheck_Core_Utils_AppFolder" data-uid="AutoCheck.Core.Utils.AppFolder">AppFolder</h4>
@@ -328,7 +328,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Utils_ConfigFolder.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Utils.ConfigFolder%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Utils.cs/#L62">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Utils.cs/#L62">View Source</a>
   </span>
   <a id="AutoCheck_Core_Utils_ConfigFolder_" data-uid="AutoCheck.Core.Utils.ConfigFolder*"></a>
   <h4 id="AutoCheck_Core_Utils_ConfigFolder" data-uid="AutoCheck.Core.Utils.ConfigFolder">ConfigFolder</h4>
@@ -360,7 +360,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Utils_CurrentOS.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Utils.CurrentOS%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Utils.cs/#L82">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Utils.cs/#L82">View Source</a>
   </span>
   <a id="AutoCheck_Core_Utils_CurrentOS_" data-uid="AutoCheck.Core.Utils.CurrentOS*"></a>
   <h4 id="AutoCheck_Core_Utils_CurrentOS" data-uid="AutoCheck.Core.Utils.CurrentOS">CurrentOS</h4>
@@ -391,7 +391,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Utils_ExecutionFolder.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Utils.ExecutionFolder%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Utils.cs/#L52">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Utils.cs/#L52">View Source</a>
   </span>
   <a id="AutoCheck_Core_Utils_ExecutionFolder_" data-uid="AutoCheck.Core.Utils.ExecutionFolder*"></a>
   <h4 id="AutoCheck_Core_Utils_ExecutionFolder" data-uid="AutoCheck.Core.Utils.ExecutionFolder">ExecutionFolder</h4>
@@ -423,7 +423,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Utils_TempFolder.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Utils.TempFolder%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Utils.cs/#L72">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Utils.cs/#L72">View Source</a>
   </span>
   <a id="AutoCheck_Core_Utils_TempFolder_" data-uid="AutoCheck.Core.Utils.TempFolder*"></a>
   <h4 id="AutoCheck_Core_Utils_TempFolder" data-uid="AutoCheck.Core.Utils.TempFolder">TempFolder</h4>
@@ -457,7 +457,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Utils_ConfigFile_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Utils.ConfigFile(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Utils.cs/#L186">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Utils.cs/#L186">View Source</a>
   </span>
   <a id="AutoCheck_Core_Utils_ConfigFile_" data-uid="AutoCheck.Core.Utils.ConfigFile*"></a>
   <h4 id="AutoCheck_Core_Utils_ConfigFile_System_String_" data-uid="AutoCheck.Core.Utils.ConfigFile(System.String)">ConfigFile(String)</h4>
@@ -506,7 +506,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Utils_PathToCurrentOS_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Utils.PathToCurrentOS(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Utils.cs/#L164">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Utils.cs/#L164">View Source</a>
   </span>
   <a id="AutoCheck_Core_Utils_PathToCurrentOS_" data-uid="AutoCheck.Core.Utils.PathToCurrentOS*"></a>
   <h4 id="AutoCheck_Core_Utils_PathToCurrentOS_System_String_" data-uid="AutoCheck.Core.Utils.PathToCurrentOS(System.String)">PathToCurrentOS(String)</h4>
@@ -555,7 +555,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Utils_PathToRemoteOS_System_String_AutoCheck_Core_Utils_OS_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Utils.PathToRemoteOS(System.String%2CAutoCheck.Core.Utils.OS)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Utils.cs/#L175">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Utils.cs/#L175">View Source</a>
   </span>
   <a id="AutoCheck_Core_Utils_PathToRemoteOS_" data-uid="AutoCheck.Core.Utils.PathToRemoteOS*"></a>
   <h4 id="AutoCheck_Core_Utils_PathToRemoteOS_System_String_AutoCheck_Core_Utils_OS_" data-uid="AutoCheck.Core.Utils.PathToRemoteOS(System.String,AutoCheck.Core.Utils.OS)">PathToRemoteOS(String, Utils.OS)</h4>
@@ -609,7 +609,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Utils_RemoveDiacritics_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Utils.RemoveDiacritics(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Utils.cs/#L105">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Utils.cs/#L105">View Source</a>
   </span>
   <a id="AutoCheck_Core_Utils_RemoveDiacritics_" data-uid="AutoCheck.Core.Utils.RemoveDiacritics*"></a>
   <h4 id="AutoCheck_Core_Utils_RemoveDiacritics_System_String_" data-uid="AutoCheck.Core.Utils.RemoveDiacritics(System.String)">RemoveDiacritics(String)</h4>
@@ -659,7 +659,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Utils_RunWithRetry__1_Action_System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Utils.RunWithRetry%60%601(Action%2CSystem.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Utils.cs/#L131">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Utils.cs/#L131">View Source</a>
   </span>
   <a id="AutoCheck_Core_Utils_RunWithRetry_" data-uid="AutoCheck.Core.Utils.RunWithRetry*"></a>
   <h4 id="AutoCheck_Core_Utils_RunWithRetry__1_Action_System_Int32_System_Int32_" data-uid="AutoCheck.Core.Utils.RunWithRetry``1(Action,System.Int32,System.Int32)">RunWithRetry&lt;T&gt;(Action, Int32, Int32)</h4>
@@ -721,7 +721,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Utils_RunWithRetry__2_Func___0__System_Int32_System_Int32_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Utils.RunWithRetry%60%602(Func%7B%60%600%7D%2CSystem.Int32%2CSystem.Int32)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Utils.cs/#L144">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Utils.cs/#L144">View Source</a>
   </span>
   <a id="AutoCheck_Core_Utils_RunWithRetry_" data-uid="AutoCheck.Core.Utils.RunWithRetry*"></a>
   <h4 id="AutoCheck_Core_Utils_RunWithRetry__2_Func___0__System_Int32_System_Int32_" data-uid="AutoCheck.Core.Utils.RunWithRetry``2(Func{``0},System.Int32,System.Int32)">RunWithRetry&lt;R, T&gt;(Func&lt;R&gt;, Int32, Int32)</h4>
@@ -801,7 +801,7 @@
     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Utils_ToCamelCase_System_String_.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Utils.ToCamelCase(System.String)%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A">Improve this Doc</a>
   </span>
   <span class="small pull-right mobile-hide">
-    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Utils.cs/#L94">View Source</a>
+    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Utils.cs/#L94">View Source</a>
   </span>
   <a id="AutoCheck_Core_Utils_ToCamelCase_" data-uid="AutoCheck.Core.Utils.ToCamelCase*"></a>
   <h4 id="AutoCheck_Core_Utils_ToCamelCase_System_String_" data-uid="AutoCheck.Core.Utils.ToCamelCase(System.String)">ToCamelCase(String)</h4>
@@ -856,7 +856,7 @@
                     <a href="https://github.com/FherStk/AutoCheck/new/master/apiSpec/new?filename=AutoCheck_Core_Utils.md&amp;value=---%0Auid%3A%20AutoCheck.Core.Utils%0Asummary%3A%20'*You%20can%20override%20summary%20for%20the%20API%20here%20using%20*MARKDOWN*%20syntax'%0A---%0A%0A*Please%20type%20below%20more%20information%20about%20this%20API%3A*%0A%0A" class="contribution-link">Improve this Doc</a>
                   </li>
                   <li>
-                    <a href="https://github.com/FherStk/AutoCheck/blob/master/core/main/Utils.cs/#L28" class="contribution-link">View Source</a>
+                    <a href="https://github.com/FherStk/AutoCheck/blob/v2.12.2/core/main/Utils.cs/#L28" class="contribution-link">View Source</a>
                   </li>
                 </ul>
               </div>

--- a/docs/html/manifest.json
+++ b/docs/html/manifest.json
@@ -1,12 +1,9 @@
 {
   "homepages": [],
-  "source_base_path": "/home/fher/repos/AutoCheck/docs",
+  "source_base_path": "/home/fher/repo/AutoCheck/docs",
   "xrefmap": "xrefmap.yml",
   "files": [
     {
-      "log_codes": [
-        "DuplicateUids"
-      ],
       "type": "ManagedReference",
       "source_relative_path": "api/AutoCheck.Connectors.Css.yml",
       "output": {
@@ -15,7 +12,7 @@
           "hash": "VG0tnfcJJvtsDS4iL4Us8Bx1ZbVWUv472RZYdMV9/UE="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -30,13 +27,10 @@
           "hash": "Uj4el8zdTiJlyfrYB+XXCAbRFfLO30oD9nfjiZQXy2E="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
-      "log_codes": [
-        "DuplicateUids"
-      ],
       "type": "ManagedReference",
       "source_relative_path": "api/AutoCheck.Connectors.CsvDocument.yml",
       "output": {
@@ -45,7 +39,7 @@
           "hash": "h8l7lIyVcg+pjfQarCaCeJ2KctmKi8yYjPZpBEgwd3w="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -60,7 +54,7 @@
           "hash": "J9sfjJNRVImRTcwP52hrfXxsaC1RsMHm4+HAOVK1PMc="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -72,7 +66,7 @@
           "hash": "PRe9J9ImYAp7N11fLc6mv4bHoSSTL1anZi0Nxeggx60="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -84,7 +78,7 @@
           "hash": "d4+IuL149ITOvFdptjRbII9x3VE3jyz2P7KFlc8Ghcc="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -96,13 +90,10 @@
           "hash": "VM+psRkwmLIMxVb0bxuOLmHfAgdY4YQbzi+PdcsvmKk="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
-      "log_codes": [
-        "DuplicateUids"
-      ],
       "type": "ManagedReference",
       "source_relative_path": "api/AutoCheck.Connectors.Odoo.yml",
       "output": {
@@ -111,7 +102,7 @@
           "hash": "Pqu75EZYyRHn3cKrHJ1olgvdLYUSIDexL6U56H9oRJ8="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -123,7 +114,7 @@
           "hash": "eexmhj+mlSmhuLjNA/6gKiFxJvZKcYjL97G3pV6hRrw="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -135,7 +126,7 @@
           "hash": "/6TcUI5dXhw6lnaTPlly0tnUhA7LOzQ5eBz2BtvGfLc="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -147,7 +138,7 @@
           "hash": "PeLssG327dJL7aqTWCOB5Dujcz9TmJbmq9GpiP2LUAA="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -162,7 +153,7 @@
           "hash": "OfBy2C7g079juIBHveGrhn9LQpCn7mPydBNj5ZqwHcA="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -174,7 +165,7 @@
           "hash": "u7kOezTR8U3SUe6s/uPXRQti4eftTCB6Ry5B1w8ggeg="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -183,10 +174,10 @@
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Connectors.html",
-          "hash": "U6i9w1UxysfNvaS2gh457uwZfLiyUJGeQpdhp9sR19s="
+          "hash": "GC0UDcchI+6QUT1pP520f7+ktFKq6+p+FcZF5JX85uc="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -201,13 +192,10 @@
           "hash": "9P+u1LTjJHXh0mh8ZGbV+acQgekSqzc4nfFhOMvtGh4="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
-      "log_codes": [
-        "DuplicateUids"
-      ],
       "type": "ManagedReference",
       "source_relative_path": "api/AutoCheck.CopyDetectors.Html.yml",
       "output": {
@@ -216,7 +204,7 @@
           "hash": "4WqWQgHiZXrZdjhAdZjauuHDH77QoxpLBVTfyLwp3v8="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -228,13 +216,10 @@
           "hash": "zyBHKIUrAHshtw1d7Uhk1qpW3XsQTGYNJoXcExP+Luo="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
-      "log_codes": [
-        "DuplicateUids"
-      ],
       "type": "ManagedReference",
       "source_relative_path": "api/AutoCheck.CopyDetectors.PlainText.yml",
       "output": {
@@ -243,13 +228,10 @@
           "hash": "giq5TriC5BsthPJScTpfppky21DtfT9k7gGMIPiEMbM="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
-      "log_codes": [
-        "DuplicateUids"
-      ],
       "type": "ManagedReference",
       "source_relative_path": "api/AutoCheck.CopyDetectors.SqlLog.yml",
       "output": {
@@ -258,19 +240,22 @@
           "hash": "CU+B6wyExIYKxjM7xXXlu9yMLL2nAPD7C8j3J/R4Q9U="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
+      "log_codes": [
+        "DuplicateUids"
+      ],
       "type": "ManagedReference",
       "source_relative_path": "api/AutoCheck.CopyDetectors.yml",
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.CopyDetectors.html",
-          "hash": "6fT0o3xez37LB/QFbKs8wl8lMWQvxEinSbK+Q8wu59o="
+          "hash": "QDRpL8v/VaaGugFmbGxgTkBCE6IyK7KZY2dOxDciWio="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -279,10 +264,10 @@
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Connectors.Atom.html",
-          "hash": "FoO/MGgfK90wfy7zag2aFLCmIV3+ndMutfZGZpDHON8="
+          "hash": "Tfk0BYZYM4X1zQpxmLVtywX8GIPQZr/QrW64AuyGROs="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -291,22 +276,25 @@
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Connectors.Base.html",
-          "hash": "rYdMd0ZEGYL8/cKdVCApw3hk3x9YPW+xFJWlKF12ELw="
+          "hash": "nDqYrMVmPpRZG9VO+H0KJ2roSpoH5qa0VHMHjxIiqNY="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
+      "log_codes": [
+        "DuplicateUids"
+      ],
       "type": "ManagedReference",
       "source_relative_path": "api/AutoCheck.Core.Connectors.Css.yml",
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Connectors.Css.html",
-          "hash": "V5IplVndGipNSTxzNhTWOnAtDH2BmuPWYMBLJAU4adk="
+          "hash": "XiyHYnaQ7s8VdlX6TRqmljSQx1LtpOdTrAfPXN+NMNI="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -315,22 +303,25 @@
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Connectors.Csv.html",
-          "hash": "qV+bX+E25KhBZPz1R3+/xRz/2ezy1h7pXaw8sVlUaUE="
+          "hash": "yDP8z1PUes0dejC7XkJPY08oXT0HU+qshvE04Synyxo="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
+      "log_codes": [
+        "DuplicateUids"
+      ],
       "type": "ManagedReference",
       "source_relative_path": "api/AutoCheck.Core.Connectors.CsvDocument.yml",
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Connectors.CsvDocument.html",
-          "hash": "qO0zz8t93hOtlMfn26ySFjHzPObJgydkLe+S02e1l+E="
+          "hash": "NptdtH52IgrcfSKlsc8Gh5FQ6EWUJjRS+xOQNDNIIV0="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -339,10 +330,10 @@
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Connectors.GDrive.html",
-          "hash": "1vn/L+FocxLLdqBdVaToREzOAZhbZkwnw4tX95N0ayY="
+          "hash": "kEzYPG/EpAayezP4y9PbKZ39ux4LCEHpHE8O8pooMvM="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -354,10 +345,10 @@
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Connectors.Html.html",
-          "hash": "SgGcRp5XRyEQH4aB2GqXE7nhxAJp4aAM6Lr7hDmDdjU="
+          "hash": "/qkiOdbvYLVh+sTtsCU/IjHcfy3TfXurS9QjwmzlmOs="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -366,22 +357,25 @@
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Connectors.Math.html",
-          "hash": "vK5KBpZmMZ7sTnTn/17gJ3K+lQ5ff9TzJ3wnA0oKgac="
+          "hash": "/HOMm0rlKal76Jy+0T8LdYO6l7xAdFdWHDa8FCPZvcQ="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
+      "log_codes": [
+        "DuplicateUids"
+      ],
       "type": "ManagedReference",
       "source_relative_path": "api/AutoCheck.Core.Connectors.Odoo.yml",
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Connectors.Odoo.html",
-          "hash": "9zBM8BdBSLOP9Md7np77wbl6fAtCm3wgagE1WDWLllU="
+          "hash": "2iHcRewztN41d+RQrQeLtT8GymDo0SrktzZw1IE1mm0="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -390,10 +384,10 @@
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Connectors.Operator.html",
-          "hash": "1E/y0rhMBdGKAYVVp3n2L8fC0fTN0BKLlSHM8mOF7Qo="
+          "hash": "t95V0MCjWQYfVxBJ9tD40RTEDjNUWyyuHZGGMfv0fOQ="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -402,10 +396,10 @@
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Connectors.PlainText.PlainTextDocument.html",
-          "hash": "OWbU8SmbrWbf742s2O16fXpljMVqEXRlqBOvnRym6RA="
+          "hash": "Owne8A864N1krm1k4Vqoc59aTJyW7QTnjkNjdxvw7Tk="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -414,10 +408,10 @@
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Connectors.PlainText.html",
-          "hash": "bHYsaLNbmrnfxQZbTPIv1hsGRjfotcP/YkPHPN+Jmhs="
+          "hash": "yfZ19uJcd8j56S035XgCFCajJBmWTlsVeeEPhImHSvY="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -426,10 +420,10 @@
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Connectors.Postgres.html",
-          "hash": "VTEzvYJlIPalticW+l3zH2oQinOLYlHgV0hT9g8gRFo="
+          "hash": "PftSCLPvs1rTFwSzOF8R5vM+oI1W4q2521XSZaEO5F0="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -438,10 +432,10 @@
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Connectors.Rss.html",
-          "hash": "NzCHDHqoRLtP+k8MjI+Wo+x8ZG6BlrxCYTuqbg64Scw="
+          "hash": "ihx1GcvJYUO/92XU4t9hTSnOVtwbRC5T1wQmzBfRkWU="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -450,10 +444,10 @@
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Connectors.Shell.html",
-          "hash": "IgcPgJ5xmLlOCrl9aWc4It4qRmIKomwuBHUQG6IP99k="
+          "hash": "prAUksATNeOa8D4YNiARJf4w/0/xYylTs8vVG2pDiUM="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -462,10 +456,10 @@
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Connectors.Xml.XmlNodeType.html",
-          "hash": "K8DFRamoMKCPorwZcDaUT+ofX0aqmNdSuYu+jd1MYP8="
+          "hash": "4p1llREz5mZaCgG0j4QY8XGVwcU82iBQuBhdgr+SKCw="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -474,10 +468,10 @@
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Connectors.Xml.html",
-          "hash": "bp+bOSgzEkbZY+r3y4HERmqrEvBUjyymkzn41Vd5T0Q="
+          "hash": "etO1Oyjuqdm+qOvhSee/8enD4klTcosBMp3srN6YG4c="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -486,10 +480,10 @@
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Connectors.Zip.html",
-          "hash": "8vFbh58Wm8Gr7e2XXiBWJHW4+3zLph2nL2eMKP/bMYE="
+          "hash": "9duQpSIPcbj5eRkJPEq7/s8ttfc55l4tBbOHmWIyxCs="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -501,10 +495,10 @@
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Connectors.html",
-          "hash": "CnEXRYS9m4oYnOIbWgK/YL583PGc5/n9jsEb2VlJa0U="
+          "hash": "4+X1moipRzn8q5kdWJqp/8mFfDF9I247d6LmK8Mi+F0="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -513,10 +507,10 @@
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.CopyDetectors.Base.html",
-          "hash": "ww2UBhm1YklckJpW93NQ43/V9cpqqze9KsRrBnG2GCI="
+          "hash": "MVgBvGmhCMKd+MHIJ5KDE7k+wpmbeckTNRb0f7Z9FWk="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -525,46 +519,55 @@
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.CopyDetectors.Css.html",
-          "hash": "6mQWVz510ow5f//eWiGXCnhYMzmG7OgRU0W1P/EDAcQ="
+          "hash": "aJAWVvOw/iqyZbYhEQRkMSv2mHBxWVbIEw0OZFajYKM="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
+      "log_codes": [
+        "DuplicateUids"
+      ],
       "type": "ManagedReference",
       "source_relative_path": "api/AutoCheck.Core.CopyDetectors.Html.yml",
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.CopyDetectors.Html.html",
-          "hash": "SAnBYFP+pJSgeYLvZ2DAbpF+QXbtO/6ZyQTFswfEyLs="
+          "hash": "JKI//A0pP0zZKJ490zUYS4Q5Xa84b/gNZDpYk1wurnw="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
+      "log_codes": [
+        "DuplicateUids"
+      ],
       "type": "ManagedReference",
       "source_relative_path": "api/AutoCheck.Core.CopyDetectors.PlainText.yml",
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.CopyDetectors.PlainText.html",
-          "hash": "qKvEP4RqOItbQ6oAuAyG42qHN6i/F5kRFWuAHdnnrOA="
+          "hash": "U1dRbJEegR97yevCZd7rL1qbo1jhjHrhkaFdXSSUEiU="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
+      "log_codes": [
+        "DuplicateUids"
+      ],
       "type": "ManagedReference",
       "source_relative_path": "api/AutoCheck.Core.CopyDetectors.SqlLog.yml",
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.CopyDetectors.SqlLog.html",
-          "hash": "cZgoiR7qUWgjCwifjvzTas1U02UYo83DidjKafC/1Xk="
+          "hash": "NBziG04Xx4WXRCgESQMHoStARwBiHk8qtWuObdbyWiE="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -573,25 +576,22 @@
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.CopyDetectors.Xml.html",
-          "hash": "RoH24gGW/pC84xWVM/s2kpRrriQREWn3BpsRFt0YrGc="
+          "hash": "viBfp8FQ6HNpi5DTz2pDkIpQlkkBrcc6aOXk2/VwZaE="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
-      "log_codes": [
-        "DuplicateUids"
-      ],
       "type": "ManagedReference",
       "source_relative_path": "api/AutoCheck.Core.CopyDetectors.yml",
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.CopyDetectors.html",
-          "hash": "YXSHtcJrt493ttdsv7vxUB/OWS0xmXULjBAYKGLoVpA="
+          "hash": "xVlfLt4qc2eYHb9WuMjYUZk04EvDxsWAoaR07EXFa1Q="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -603,10 +603,10 @@
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Exceptions.ArgumentInvalidException.html",
-          "hash": "Eqbc5qgsh4sv/zK9gor2VE9Ks8t30RXb+A8DcoxzZTI="
+          "hash": "RkT9mGZerlvK1Zg36QZHQoOwYKc0Ta0tyEzTIei4sNc="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -615,25 +615,22 @@
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Exceptions.ArgumentNotFoundException.html",
-          "hash": "A1YbYZQjr/j0YFernqwgAOj1y710oKqSf8PvqEFl7y0="
+          "hash": "Ozi/dFIQQhN0a5S9QPD3fIKZ4loK4pb5+PRM7m9XvCg="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
-      "log_codes": [
-        "DuplicateUids"
-      ],
       "type": "ManagedReference",
       "source_relative_path": "api/AutoCheck.Core.Exceptions.ConnectionInvalidException.yml",
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Exceptions.ConnectionInvalidException.html",
-          "hash": "qRkcPdeNGENHOBtOBcKbR2VbqPWcpT3PQZEJrJFSTRA="
+          "hash": "mahXOb+ThZgwfZ3rqB1GWW3U9iWyj+LwZz/9Jv+OrA8="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -642,10 +639,10 @@
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Exceptions.ConnectorInvalidException.html",
-          "hash": "ITf86wxVTV18KSM2Bx9cRsPTFod2X/RcLaAh0wqposM="
+          "hash": "nEDKR+gIZ7izVRZp3GG4+UjkNLNO+RFuSS0lL6MakkI="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -654,34 +651,40 @@
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Exceptions.ConnectorNotFoundException.html",
-          "hash": "o/J1xjuvnIK08tUR/gXTsY9H/4ZDwFVUO+i6Gxrt4mU="
+          "hash": "M1lA+tUDbwkCFOheIn5jJBOaGn2YJoPAj7adIHq8UqA="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
+      "log_codes": [
+        "DuplicateUids"
+      ],
       "type": "ManagedReference",
       "source_relative_path": "api/AutoCheck.Core.Exceptions.DocumentInvalidException.yml",
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Exceptions.DocumentInvalidException.html",
-          "hash": "qvGRcj8xb9hXLrjOL9Ur4fPmwnfG/tqk4cBx1yRs5GU="
+          "hash": "knEHr2WkcqxVtmJg8StSk1BZpHnfvQJeCFhujXX6Tdc="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
+      "log_codes": [
+        "DuplicateUids"
+      ],
       "type": "ManagedReference",
       "source_relative_path": "api/AutoCheck.Core.Exceptions.DownloadFailedException.yml",
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Exceptions.DownloadFailedException.html",
-          "hash": "6xUxyn0azUkggxSYUmx37O9+TgZE1iC3AzxrIEA00G8="
+          "hash": "m0+PuR4gchf8UcBEpDxulEz9EQjkfEap7M3JgmhvxC4="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -690,10 +693,10 @@
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Exceptions.ItemNotFoundException.html",
-          "hash": "gXhQZyfYHjT6ChzNnVLt/2LrcgDNoChJXa6PEEO/Bak="
+          "hash": "nwvofWzMM8tjDfomy+XzsOc2kPUkW6xqmWiPPP2adwQ="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -702,25 +705,22 @@
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Exceptions.PorpertyNotFoundException.html",
-          "hash": "hyWDrUJKRJRFfFamDgTxDYpVFrfsbN+soz3OjQ3VJ1g="
+          "hash": "YDuCzmhJ24t0rfmK5Gun9QxGQxhxf3RQgEn17admpWc="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
-      "log_codes": [
-        "DuplicateUids"
-      ],
       "type": "ManagedReference",
       "source_relative_path": "api/AutoCheck.Core.Exceptions.QueryInvalidException.yml",
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Exceptions.QueryInvalidException.html",
-          "hash": "np9JsHVQ2T/1yQaINiYZ0MET6PNUO8OUIrV4zjLqNfE="
+          "hash": "nsRvE58E//QYcxtdMCb5jj7EZElIjzEinA1zC/wo28U="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -732,10 +732,10 @@
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Exceptions.RegexInvalidException.html",
-          "hash": "56wjNZiaI09oEtYq7Eklv4etM+yXgBb/z8K/XCvxs9g="
+          "hash": "o2cW3k+HXEbdpb4mh1hrYttnxmzI1uOZXIsLCWQK3cI="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -744,10 +744,10 @@
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Exceptions.ResultMismatchException.html",
-          "hash": "31o4N9reimqh3/umTIh5ZucCyvtpqfPB0idYsFoGAxg="
+          "hash": "tSB2Y1JPzC6YGhaslR/sP20S/p1DH6RQ9gKF2mYPnFE="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -756,10 +756,10 @@
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Exceptions.StyleInvalidException.html",
-          "hash": "JFyw/hYYk1d5TtZN/ItHpr03K/r1hJ+RCmDDa4FS698="
+          "hash": "ujq+Egs4p+dpXQ5KRC0Ot9wZxxDp9ekBKSuFa0XCCFU="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -768,10 +768,10 @@
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Exceptions.StyleNotAppliedException.html",
-          "hash": "esAqIiF0Zuy4n8UbOR9tGrj31a70/WZuXKqmQ6mJiUE="
+          "hash": "DkbDt5LARnM4fsdE4pbgkjDN/sSVwGEOFU16Ls9K6Fw="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -783,10 +783,10 @@
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Exceptions.StyleNotFoundException.html",
-          "hash": "xhTA4ZEniRgcZIKYilF5O2/CvMxSba3gzS32Lwae36Y="
+          "hash": "5a7fsHQ3jiaJIUd6H15b/88nYwVSLOvTu+sBwmfxi2s="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -795,10 +795,10 @@
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Exceptions.TableInconsistencyException.html",
-          "hash": "h95KPLzM8s/SGGlbeg7kqH6oV79a6caTcdHnG/26MI4="
+          "hash": "hCz76BSwzu663stMUIstIl+5UYeUmCBENXzxO11G/V4="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -807,10 +807,10 @@
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Exceptions.VariableInvalidException.html",
-          "hash": "H5s1NkR5g6sVvpHs0nPKNFZq8Jn5XV/+aiz9esq27X0="
+          "hash": "pYkYTBt8xDWIax+sxkb9mKHzTNep0Sysfh1YhCVaqSk="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -819,10 +819,10 @@
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Exceptions.VariableNotFoundException.html",
-          "hash": "VhdMhpLbYGyMqMKIZVI3U46ZrmTzsdlZz2b9Hq70thY="
+          "hash": "8x6k6WbYQ39C+cfDco/8hMq3ie1f4mEGlJKXH3e+Rrc="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -834,7 +834,7 @@
           "hash": "/E1ESjzNy8a1mM7ZGsqANt/khA21zJAzbyoHBGMuIZ8="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -843,10 +843,10 @@
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Output.Log.html",
-          "hash": "Y1tz3RhqrBeTARm038VKTKr4LgFlQpVcVYyqqfv9K80="
+          "hash": "jazyc5dFtsylGYJqXzzwnwmCK13vDjVYF7jErB7TwVc="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -855,10 +855,10 @@
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Output.Style.html",
-          "hash": "93pxsnDXn4gmPPEo4ozvwVAsKA2YRXanembYpL+sUfs="
+          "hash": "glXXGaAsA1Eqw7HLldMgm3BYVL79O+Om0NiMDD3mK4A="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -867,10 +867,10 @@
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Output.Type.html",
-          "hash": "/2N0ui8kNOucF1av6aNwC9Pdl0nJ0qepnbF5vokAQDs="
+          "hash": "PE6VRbD+J27Edn7KXCtMc9y/+fnXTT+j2MlcUZd49LU="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -879,10 +879,10 @@
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Output.html",
-          "hash": "/GIbsXXeihvP+5ldH5wYSj1WlqHmuT0kTIQDJQYPSEk="
+          "hash": "Rt7CJGocpJAs0hHHTtrn/0u1jWIAfrBNEFZ/EicvJnM="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -891,10 +891,10 @@
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Script.ExecutionModeType.html",
-          "hash": "7elKA7/3WMULso30qDDgq9TznGCuTIWES5ir+TTcbY4="
+          "hash": "RA93u8Daa0giPh+297Yty8TLr3bcbeR4YiSeGJkxpFs="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -903,10 +903,10 @@
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Script.LogGeneratedEventArgs.html",
-          "hash": "wH8zjFu321B35nGGw0/aoxJ8fv+4t/d4D4RUy7vDMBY="
+          "hash": "LCa1Z0tjH83XQykltBJiODwhQPXympkJD9w2oKLpkKA="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -915,10 +915,10 @@
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Script.html",
-          "hash": "uwXaBAyw6IAnfFs3+S1mN28lpmA69ZvXXWzLlP8iG1Q="
+          "hash": "UDAtGJlYdqP5kzGvpxhZNniap6vJWXPUOOkevKQ5doQ="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -927,10 +927,10 @@
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Utils.OS.html",
-          "hash": "2kD/RjwXxyNLagDSYB5U82ds64RFP41obBP0AJH/gCc="
+          "hash": "bahK7V33U0zRmuqBO9ItOaP4JasRR2eyyJ6I0uJpLQM="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -939,10 +939,10 @@
       "output": {
         ".html": {
           "relative_path": "api/AutoCheck.Core.Utils.html",
-          "hash": "4U9CW9xL0Rmg0yLtR6V5RBVus5SQrsmDaZdgU/UEy6Q="
+          "hash": "7ouUr3huO/98PUFlDNkwha6lWWOIMN4HGq5htwT6qH0="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -954,7 +954,7 @@
           "hash": "Tr/to3g36vtO3ncin21hyQYdJp/xpuw5fuJq6i+DIs8="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -966,10 +966,13 @@
           "hash": "Y1g3upU5wwsxaxYcanot+0kXuG6Fm5cMwu2Td5K3+J0="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
+      "log_codes": [
+        "DuplicateUids"
+      ],
       "type": "ManagedReference",
       "source_relative_path": "api/AutoCheck.Exceptions.ConnectionInvalidException.yml",
       "output": {
@@ -978,13 +981,10 @@
           "hash": "vSeoHuvINuwFj1d1OXEd3aPTOK1fmzsJhkNvQnzohmA="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
-      "log_codes": [
-        "DuplicateUids"
-      ],
       "type": "ManagedReference",
       "source_relative_path": "api/AutoCheck.Exceptions.DocumentInvalidException.yml",
       "output": {
@@ -993,13 +993,10 @@
           "hash": "ZjxJxURMBwDEIZ77BZ+twSpBDH54HuoCA74HhlwuVmo="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
-      "log_codes": [
-        "DuplicateUids"
-      ],
       "type": "ManagedReference",
       "source_relative_path": "api/AutoCheck.Exceptions.DownloadFailedException.yml",
       "output": {
@@ -1008,10 +1005,13 @@
           "hash": "iGAiUyzJZLgcRgQsQHXKPOKiMzYgF3stuJalNG83P5Y="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
+      "log_codes": [
+        "DuplicateUids"
+      ],
       "type": "ManagedReference",
       "source_relative_path": "api/AutoCheck.Exceptions.QueryInvalidException.yml",
       "output": {
@@ -1020,7 +1020,7 @@
           "hash": "h+OYUNdJoKNKS6t4uuNc6RrFZZqIL5hziqkVCZ2gMiU="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -1032,7 +1032,7 @@
           "hash": "3uM71CHm8dGvPrG1h1plpTJ2S0oKmppm9bTf2dhyXXM="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -1047,7 +1047,7 @@
           "hash": "3Ptkd6SeEY+FRp/yO2QgS/oRpG4uJEldpAKulocBFjg="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -1059,7 +1059,7 @@
           "hash": "IP8fnmL2S2vr/bIX2XS3USmSpiXA4kaujtUq0gHVs+Q="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -1074,7 +1074,7 @@
           "hash": "MuBxKYmH/BXLdrtA/kzjWDRV0+jXrkJz3eE4jb/1gaI="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -1089,7 +1089,7 @@
           "hash": "AIIUtB9DCXWMo4RjTb+yH01zGcsrlEIN3+49AE9576Q="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -1104,7 +1104,7 @@
           "hash": "yR16JfikpsKb3pPbJas0qcSMWgk3GoAl9pXkddY8pi8="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -1116,7 +1116,7 @@
           "hash": "Va1zChmAF3Q9UFtJUOtivxhDZW8GM6pyNzNstRPpcss="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -1184,7 +1184,7 @@
           "hash": "GDy2/oY0FA3L1qL7wMbuKuGhd6khQPB92y00IbBE39E="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -1193,10 +1193,10 @@
       "output": {
         ".html": {
           "relative_path": "tutorials/student.html",
-          "hash": "Eoi3YoEu5rTrA0R7WmQQtFzD+EUSM5oOH3IUFnRoI5E="
+          "hash": "MAZGTk5Fbp8hfopa4h92T8Tf5Rg4SneROZ73egTqOFM="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     },
     {
@@ -1208,30 +1208,32 @@
           "hash": "OjVOJ5HKRtSQMbIMwVlyGU4Nw3haFQSHUVCid9qLoMw="
         }
       },
-      "is_incremental": true,
+      "is_incremental": false,
       "version": ""
     }
   ],
   "incremental_info": [
     {
       "status": {
-        "can_incremental": true,
+        "can_incremental": false,
+        "details": "Cannot build incrementally because last build info is missing.",
         "incrementalPhase": "build",
         "total_file_count": 0,
-        "skipped_file_count": 0
+        "skipped_file_count": 0,
+        "full_build_reason_code": "NoAvailableBuildCache"
       },
       "processors": {
         "ConceptualDocumentProcessor": {
-          "can_incremental": true,
+          "can_incremental": false,
           "incrementalPhase": "build",
           "total_file_count": 5,
-          "skipped_file_count": 4
+          "skipped_file_count": 0
         },
         "ManagedReferenceDocumentProcessor": {
-          "can_incremental": true,
+          "can_incremental": false,
           "incrementalPhase": "build",
           "total_file_count": 86,
-          "skipped_file_count": 86
+          "skipped_file_count": 0
         },
         "ResourceDocumentProcessor": {
           "can_incremental": false,
@@ -1251,8 +1253,8 @@
     },
     {
       "status": {
-        "can_incremental": true,
-        "details": "Can support incremental post processing.",
+        "can_incremental": false,
+        "details": "Cannot support incremental post processing, the reason is: last post processor info is null.",
         "incrementalPhase": "postProcessing",
         "total_file_count": 0,
         "skipped_file_count": 0

--- a/docs/html/tutorials/student.html
+++ b/docs/html/tutorials/student.html
@@ -122,6 +122,7 @@
 <li>Download the application with the following command: <code>git clone https://github.com/FherStk/AutoCheck.git</code>.</li>
 <li>Go to the client app folder with the following command: <code>cd AutoCheck/terminal</code>.</li>
 <li>Compile the application with the following command: <code>dotnet build -c Release</code>.</li>
+<li>GNU/Linux only: give permissions to the startup file with: <code>chmod +x start.sh</code>.</li>
 </ol>
 <h3 id="preparation">Preparation</h3>
 <p>Please, notice that <strong>AutoCheck will revert all changes when updates</strong> which includes the removal of new files, so it's important to <strong>copy the scripts</strong> you want to modify into the <code>AutoCheck/scripts/custom</code> folder:</p>
@@ -135,21 +136,24 @@
 <ol>
 <li>Open a terminal and go into the application's terminal folder: <code>cd AutoCheck/terminal</code>.</li>
 <li>Go into the application's binary (executable) folder: <code>cd bin/Release/net6.0</code>.</li>
-<li>Run the application with <code>dotnet AutoCheck.Terminal.dll &quot;path_to_file.yaml&quot;</code>, for example: <code>dotnet AutoCheck.Terminal.dll ../scripts/custom/xml_validation_single.yaml</code></li>
+<li>For GNU/Linux: run the application with <code>./run.sh &quot;path_to_file.yaml&quot;</code>, for example: <code>./run.sh ../scripts/custom/xml_validation_single.yaml</code></li>
+<li>For Windows: run the application with <code>run &quot;path_to_file.yaml&quot;</code>, for example: <code>run ../scripts/custom/xml_validation_single.yaml</code></li>
 </ol>
 <h3 id="run-with-no-update">Run (with no update)</h3>
 <p>AutoCheck will automatically check for updates on startup, but update avoidance can be requested:</p>
 <ol>
 <li>Open a terminal and go into the application's terminal folder: <code>cd AutoCheck/terminal</code>.</li>
 <li>Go into the application's binary (executable) folder: <code>cd bin/Release/net6.0</code>.</li>
-<li>Update the application with the following command: <code>dotnet AutoCheck.Terminal.dll --no-update &quot;path_to_file.yaml&quot;</code>.</li>
+<li>For GNU/Linux: run the application avoiding updates with the following command: <code>./run.sh --no-update &quot;path_to_file.yaml&quot;</code>.</li>
+<li>For Windows: run the application avoiding updates with the following command: <code>run --no-update &quot;path_to_file.yaml&quot;</code>.</li>
 </ol>
 <h3 id="manual-update">Manual update</h3>
 <p>AutoCheck will automatically check for updates on startup, but a manual update can be requested:</p>
 <ol>
 <li>Open a terminal and go into the application's terminal folder: <code>cd AutoCheck/terminal</code>.</li>
 <li>Go into the application's binary (executable) folder: <code>cd bin/Release/net6.0</code>.</li>
-<li>Update the application with the following command: <code>dotnet AutoCheck.Terminal.dll --update</code>.</li>
+<li>For GNU/Linux: update the application with the following command: <code>./run.sh --update</code>.</li>
+<li>For Windows: update the application with the following command: <code>run --update</code>.</li>
 </ol>
 <h3 id="avaliable-scripts">Avaliable scripts</h3>
 <p>Here you will find different excamples about how to invoke existing scripts, but remember: you need to setup the target first, just need to copy the original one to the <code>scripts/custom</code> folder and change the target parameter (<code>host</code>, <code>path</code> or <code>folder</code>).</p>
@@ -159,7 +163,8 @@
 <li>Copy the <code>AutoCheck/scripts/targets/xml_validation_single.yaml</code> script into the <code>scripts/custom</code> folder.</li>
 <li>Edit the <code>AutoCheck/scripts/custom/xml_validation_single.yaml</code> script and change the <code>folder</code> parameter to point the folder where your assignment is.</li>
 <li>Open a terminal and go to the <code>terminal</code> binary (executable) folder with <code>cd AutoCheck/terminal/bin/Release/net6.0</code>.</li>
-<li>Run the script with <code>dotnet AutoCheck.Terminal.dll ../scripts/custom/xml_validation_single.yaml</code>.</li>
+<li>GNU/Linux: run the script with <code>./run.sh ../scripts/custom/xml_validation_single.yaml</code>.</li>
+<li>Windows: run the script with <code>run ../scripts/custom/xml_validation_single.yaml</code>.</li>
 </ol>
 <h4 id="dam---m04-uf1-html5-assignment">DAM - M04 UF1: HTML5 assignment</h4>
 <p>In order to check this assignment:</p>
@@ -167,7 +172,8 @@
 <li>Copy the <code>AutoCheck/scripts/targets/html5_single.yaml</code> script into the <code>scripts/custom</code> folder.</li>
 <li>Edit the <code>AutoCheck/scripts/custom/html5_single.yaml</code> script and change the <code>folder</code> parameter to point the folder where your assignment is.</li>
 <li>Open a terminal and go to the <code>terminal</code> binary (executable) folder with <code>cd AutoCheck/terminal/bin/Release/net6.0</code>.</li>
-<li>Run the script with <code>dotnet AutoCheck.Terminal.dll ../scripts/custom/html5_single.yaml</code>.</li>
+<li>GNU/Linux: run the script with <code>./run.sh ../scripts/custom/html5_single.yaml</code>.</li>
+<li>Windows: run the script with <code>run ../scripts/custom/html5_single.yaml</code>.</li>
 </ol>
 <h4 id="dam---m04-uf1-css3-assignment">DAM - M04 UF1: CSS3 assignment</h4>
 <p>In order to check this assignment:</p>
@@ -175,7 +181,8 @@
 <li>Copy the <code>AutoCheck/scripts/targets/css3_single.yaml</code> script into the <code>scripts/custom</code> folder.</li>
 <li>Edit the <code>AutoCheck/scripts/custom/css3_single.yaml</code> script and change the <code>folder</code> parameter to point the folder where your assignment is.</li>
 <li>Open a terminal and go to the <code>terminal</code> binary (executable) folder with <code>cd AutoCheck/terminal/bin/Release/net6.0</code>.</li>
-<li>Run the script with <code>dotnet AutoCheck.Terminal.dll ../scripts/custom/css3_single.yaml</code>.</li>
+<li>GNU/Linux: run the script with <code>./run.sh ../scripts/custom/css3_single.yaml</code>.</li>
+<li>Windows: run the script with <code>run ../scripts/custom/css3_single.yaml</code>.</li>
 </ol>
 <h4 id="dam---m04-uf2-web-syndication-rss--atom">DAM - M04 UF2: Web Syndication (RSS + ATOM)</h4>
 <p>In order to check this assignment:</p>
@@ -183,7 +190,8 @@
 <li>Copy the <code>AutoCheck/scripts/targets/web_syndication_single.yaml</code> script into the <code>scripts/custom</code> folder.</li>
 <li>Edit the <code>AutoCheck/scripts/custom/web_syndication_single.yaml</code> script and change the <code>folder</code> parameter to point the folder where your assignment is.</li>
 <li>Open a terminal and go to the <code>terminal</code> binary (executable) folder with <code>cd AutoCheck/terminal/bin/Release/net6.0</code>.</li>
-<li>Run the script with <code>dotnet AutoCheck.Terminal.dll ../scripts/custom/web_syndication_single.yaml</code>.</li>
+<li>GNU/Linux: run the script with <code>./run.sh ../scripts/custom/web_syndication_single.yaml</code>.</li>
+<li>Windows: run the script with <code>run ../scripts/custom/web_syndication_single.yaml</code>.</li>
 </ol>
 <h4 id="asix---m02-uf3-sql-database-permissions">ASIX - M02 UF3: SQL DataBase Permissions</h4>
 <p>In order to check this assignment:</p>
@@ -191,7 +199,8 @@
 <li>Copy the <code>AutoCheck/scripts/targets/permissions_single.yaml</code> script into the <code>scripts/custom</code> folder.</li>
 <li>Edit the <code>AutoCheck/scripts/custom/permissions_single.yaml</code> script and change the <code>host</code> parameter to point the host name or IP address where your Postgres server is listening to.</li>
 <li>Open a terminal and go to the <code>terminal</code> binary (executable) folder with <code>cd AutoCheck/terminal/bin/Release/net6.0</code>.</li>
-<li>Run the script with <code>dotnet AutoCheck.Terminal.dll ../scripts/custom/permissions_single.yaml</code>.</li>
+<li>GNU/Linux: run the script with <code>./run.sh ../scripts/custom/permissions_single.yaml</code>.</li>
+<li>Windows: run the script with <code>run ../scripts/custom/permissions_single.yaml</code>.</li>
 </ol>
 <h4 id="asix---m02-uf3-sql-database-updatable-views">ASIX - M02 UF3: SQL DataBase Updatable Views</h4>
 <p>In order to check this assignment:</p>
@@ -199,7 +208,8 @@
 <li>Copy the <code>AutoCheck/scripts/targets/views_single.yaml</code> script into the <code>scripts/custom</code> folder.</li>
 <li>Edit the <code>AutoCheck/scripts/custom/views_single.yaml</code> script and change the <code>host</code> parameter to point the host name or IP address where your Postgres server is listening to.</li>
 <li>Open a terminal and go to the <code>terminal</code> binary (executable) folder with <code>cd AutoCheck/terminal/bin/Release/net6.0</code>.</li>
-<li>Run the script with <code>dotnet AutoCheck.Terminal.dll ../scripts/custom/views_single.yaml</code>.</li>
+<li>GNU/Linux: run the script with <code>./run.sh ../scripts/custom/views_single.yaml</code>.</li>
+<li>Windows: run the script with <code>run ../scripts/custom/views_single.yaml</code>.</li>
 </ol>
 </article>
           </div>

--- a/docs/tutorials/student.md
+++ b/docs/tutorials/student.md
@@ -17,6 +17,7 @@ Follow this instructions in order to install the application for the first time:
 3. Download the application with the following command: `git clone https://github.com/FherStk/AutoCheck.git`.
 4. Go to the client app folder with the following command: `cd AutoCheck/terminal`.
 5. Compile the application with the following command: `dotnet build -c Release`.
+6. GNU/Linux only: give permissions to the startup file with: `chmod +x start.sh`.
 
 ### Preparation
 Please, notice that **AutoCheck will revert all changes when updates** which includes the removal of new files, so it's important to **copy the scripts** you want to modify into the `AutoCheck/scripts/custom` folder:
@@ -28,19 +29,22 @@ Please, notice that **AutoCheck will revert all changes when updates** which inc
 Follow this instructions in order to run the application:
 1. Open a terminal and go into the application's terminal folder: `cd AutoCheck/terminal`.
 2. Go into the application's binary (executable) folder: `cd bin/Release/net6.0`.
-3. Run the application with `dotnet AutoCheck.Terminal.dll "path_to_file.yaml"`, for example: `dotnet AutoCheck.Terminal.dll ../scripts/custom/xml_validation_single.yaml`  
+3. For GNU/Linux: run the application with `./run.sh "path_to_file.yaml"`, for example: `./run.sh ../scripts/custom/xml_validation_single.yaml`  
+4. For Windows: run the application with `run "path_to_file.yaml"`, for example: `run ../scripts/custom/xml_validation_single.yaml`  
 
 ### Run (with no update)
 AutoCheck will automatically check for updates on startup, but update avoidance can be requested:
 1. Open a terminal and go into the application's terminal folder: `cd AutoCheck/terminal`.
 2. Go into the application's binary (executable) folder: `cd bin/Release/net6.0`.
-3. Update the application with the following command: `dotnet AutoCheck.Terminal.dll --no-update "path_to_file.yaml"`. 
+3. For GNU/Linux: run the application avoiding updates with the following command: `./run.sh --no-update "path_to_file.yaml"`. 
+4. For Windows: run the application avoiding updates with the following command: `run --no-update "path_to_file.yaml"`. 
 
 ### Manual update
 AutoCheck will automatically check for updates on startup, but a manual update can be requested:
 1. Open a terminal and go into the application's terminal folder: `cd AutoCheck/terminal`.
 2. Go into the application's binary (executable) folder: `cd bin/Release/net6.0`.
-3. Update the application with the following command: `dotnet AutoCheck.Terminal.dll --update`. 
+3. For GNU/Linux: update the application with the following command: `./run.sh --update`.
+4. For Windows: update the application with the following command: `run --update`.
 
 ### Avaliable scripts
 Here you will find different excamples about how to invoke existing scripts, but remember: you need to setup the target first, just need to copy the original one to the `scripts/custom` folder and change the target parameter (`host`, `path` or `folder`).
@@ -50,39 +54,45 @@ In order to check this assignment:
 1. Copy the `AutoCheck/scripts/targets/xml_validation_single.yaml` script into the `scripts/custom` folder.
 2. Edit the `AutoCheck/scripts/custom/xml_validation_single.yaml` script and change the `folder` parameter to point the folder where your assignment is. 
 3. Open a terminal and go to the `terminal` binary (executable) folder with `cd AutoCheck/terminal/bin/Release/net6.0`.
-4. Run the script with `dotnet AutoCheck.Terminal.dll ../scripts/custom/xml_validation_single.yaml`.
+4. GNU/Linux: run the script with `./run.sh ../scripts/custom/xml_validation_single.yaml`.
+5. Windows: run the script with `run ../scripts/custom/xml_validation_single.yaml`.
 
 #### DAM - M04 UF1: HTML5 assignment
 In order to check this assignment:
 1. Copy the `AutoCheck/scripts/targets/html5_single.yaml` script into the `scripts/custom` folder.
 2. Edit the `AutoCheck/scripts/custom/html5_single.yaml` script and change the `folder` parameter to point the folder where your assignment is. 
 3. Open a terminal and go to the `terminal` binary (executable) folder with `cd AutoCheck/terminal/bin/Release/net6.0`.
-4. Run the script with `dotnet AutoCheck.Terminal.dll ../scripts/custom/html5_single.yaml`.
+4. GNU/Linux: run the script with `./run.sh ../scripts/custom/html5_single.yaml`.
+5. Windows: run the script with `run ../scripts/custom/html5_single.yaml`.
 
 #### DAM - M04 UF1: CSS3 assignment
 In order to check this assignment:
 1. Copy the `AutoCheck/scripts/targets/css3_single.yaml` script into the `scripts/custom` folder.
 2. Edit the `AutoCheck/scripts/custom/css3_single.yaml` script and change the `folder` parameter to point the folder where your assignment is. 
 3. Open a terminal and go to the `terminal` binary (executable) folder with `cd AutoCheck/terminal/bin/Release/net6.0`.
-4. Run the script with `dotnet AutoCheck.Terminal.dll ../scripts/custom/css3_single.yaml`.
+4. GNU/Linux: run the script with `./run.sh ../scripts/custom/css3_single.yaml`.
+5. Windows: run the script with `run ../scripts/custom/css3_single.yaml`.
 
 #### DAM - M04 UF2: Web Syndication (RSS + ATOM)
 In order to check this assignment:
 1. Copy the `AutoCheck/scripts/targets/web_syndication_single.yaml` script into the `scripts/custom` folder.
 2. Edit the `AutoCheck/scripts/custom/web_syndication_single.yaml` script and change the `folder` parameter to point the folder where your assignment is. 
 3. Open a terminal and go to the `terminal` binary (executable) folder with `cd AutoCheck/terminal/bin/Release/net6.0`.
-4. Run the script with `dotnet AutoCheck.Terminal.dll ../scripts/custom/web_syndication_single.yaml`.
+4. GNU/Linux: run the script with `./run.sh ../scripts/custom/web_syndication_single.yaml`.
+5. Windows: run the script with `run ../scripts/custom/web_syndication_single.yaml`.
 
 #### ASIX - M02 UF3: SQL DataBase Permissions
 In order to check this assignment:
 1. Copy the `AutoCheck/scripts/targets/permissions_single.yaml` script into the `scripts/custom` folder.
 2. Edit the `AutoCheck/scripts/custom/permissions_single.yaml` script and change the `host` parameter to point the host name or IP address where your Postgres server is listening to. 
 3. Open a terminal and go to the `terminal` binary (executable) folder with `cd AutoCheck/terminal/bin/Release/net6.0`.
-4. Run the script with `dotnet AutoCheck.Terminal.dll ../scripts/custom/permissions_single.yaml`.
+4. GNU/Linux: run the script with `./run.sh ../scripts/custom/permissions_single.yaml`.
+5. Windows: run the script with `run ../scripts/custom/permissions_single.yaml`.
 
 #### ASIX - M02 UF3: SQL DataBase Updatable Views
 In order to check this assignment:
 1. Copy the `AutoCheck/scripts/targets/views_single.yaml` script into the `scripts/custom` folder.
 2. Edit the `AutoCheck/scripts/custom/views_single.yaml` script and change the `host` parameter to point the host name or IP address where your Postgres server is listening to. 
 3. Open a terminal and go to the `terminal` binary (executable) folder with `cd AutoCheck/terminal/bin/Release/net6.0`.
-4. Run the script with `dotnet AutoCheck.Terminal.dll ../scripts/custom/views_single.yaml`.
+4. GNU/Linux: run the script with `./run.sh ../scripts/custom/views_single.yaml`.
+5. Windows: run the script with `run ../scripts/custom/views_single.yaml`.

--- a/terminal/AutoCheck.Terminal.csproj
+++ b/terminal/AutoCheck.Terminal.csproj
@@ -7,7 +7,7 @@
     <Authors>Fernando Porrino Serrano</Authors>
     <Product>AutoCheck.Terminal</Product>
     <Copyright>Copyright © 2020</Copyright>
-    <VersionPrefix>2.3.1</VersionPrefix>
+    <VersionPrefix>2.3.2</VersionPrefix>
     <VersionSuffix>stable</VersionSuffix>  
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
     <AssemblyFileVersion>$(AssemblyVersion)</AssemblyFileVersion>

--- a/terminal/run.bat
+++ b/terminal/run.bat
@@ -1,0 +1,1 @@
+dotnet bin/Release/net6.0/AutoCheck.Terminal.dll %1 %2

--- a/terminal/run.sh
+++ b/terminal/run.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+dotnet bin/Release/net6.0/AutoCheck.Terminal.dll $1 $2


### PR DESCRIPTION
## List of changes:
* The terminal app includes new files: 'run.sh' for GNU/Linux and 'run.bat' for Windows, those files helps to start the terminal app due to a bug introduced in .NET6 when its being installed using snap over Ubuntu 20.04, because 'dotnet run' under the terminal folder doesn't works anymore. 
* Several bugfixes and improvements.