### PR TITLE
Fix .net folder version on AutoCheck/cli/run.sh

### DIFF
--- a/cli/run.sh
+++ b/cli/run.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 dotnet build -c Release > /dev/null 2>&1
-dotnet bin/Release/net6.0/AutoCheck.Cli.dll $1 $2 $3
+dotnet bin/Release/net8.0/AutoCheck.Cli.dll $1 $2 $3


### PR DESCRIPTION
In `AutoCheck/cli/run.sh` the .net version folder still has the former version `dotnet bin/Release/net6.0/AutoCheck.Cli.dll $1 $2 $3` instead of the most recent `dotnet bin/Release/net8.0/AutoCheck.Cli.dll $1 $2 $3`